### PR TITLE
Decoder code cleanup.

### DIFF
--- a/dec/decode.c
+++ b/dec/decode.c
@@ -50,8 +50,9 @@ static const int kDistanceContextBits = 2;
 
 #define HUFFMAN_TABLE_BITS      8
 #define HUFFMAN_TABLE_MASK      0xff
-/* This is a rough estimate, not an exact bound. */
-#define HUFFMAN_MAX_TABLE_SIZE  2048
+/* Maximum possible Huffman table size for an alphabet size of 704, max code
+ * length 15 and root table bits 8. */
+#define HUFFMAN_MAX_TABLE_SIZE  1080
 
 #define CODE_LENGTH_CODES 18
 static const uint8_t kCodeLengthCodeOrder[CODE_LENGTH_CODES] = {
@@ -985,7 +986,6 @@ int BrotliDecompress(BrotliInput input, BrotliOutput output) {
                           block_type_rb_index, &br);
           block_length[2] = ReadBlockLength(
               &block_len_trees[2 * HUFFMAN_MAX_TABLE_SIZE], &br);
-          dist_htree_index = (uint8_t)block_type[2];
           dist_context_offset = block_type[2] << kDistanceContextBits;
           dist_context_map_slice = dist_context_map + dist_context_offset;
         }

--- a/dec/safe_malloc.h
+++ b/dec/safe_malloc.h
@@ -15,8 +15,8 @@
    Size-checked memory allocation.
 */
 
-#ifndef BROTLI_UTILS_UTILS_H_
-#define BROTLI_UTILS_UTILS_H_
+#ifndef BROTLI_DEC_SAFE_MALLOC_H_
+#define BROTLI_DEC_SAFE_MALLOC_H_
 
 #include <assert.h>
 
@@ -42,4 +42,4 @@ void* BrotliSafeMalloc(uint64_t nmemb, size_t size);
 }    /* extern "C" */
 #endif
 
-#endif  /* BROTLI_UTILS_UTILS_H_ */
+#endif  /* BROTLI_DEC_SAFE_MALLOC_H_ */

--- a/dec/transform.h
+++ b/dec/transform.h
@@ -182,7 +182,7 @@ static const Transform kTransforms[] = {
 
 static const int kNumTransforms = sizeof(kTransforms) / sizeof(kTransforms[0]);
 
-static int ToUpperCase(uint8_t *p, int len) {
+static int ToUpperCase(uint8_t *p) {
   if (p[0] < 0xc0) {
     if (p[0] >= 'a' && p[0] <= 'z') {
       p[0] ^= 32;
@@ -220,10 +220,10 @@ static BROTLI_INLINE int TransformDictionaryWord(
   while (i < len) { dst[idx++] = word[i++]; }
   uppercase = &dst[idx - len];
   if (t == kUppercaseFirst) {
-    ToUpperCase(uppercase, len);
+    ToUpperCase(uppercase);
   } else if (t == kUppercaseAll) {
     while (len > 0) {
-      int step = ToUpperCase(uppercase, len);
+      int step = ToUpperCase(uppercase);
       uppercase += step;
       len -= step;
     }


### PR DESCRIPTION
1) Use a tighter upper bound on the Huffman table size.
2) Remove unused argument len in ToUpperCase.
3) Remove unused no-op assignment in BrotliDecompress.
4) Fix include guard name.
