### PR TITLE
Disable transforms in the encoder by default.

### DIFF
--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -440,7 +440,7 @@ BrotliCompressor::BrotliCompressor(BrotliParams params)
   }
   hashers_->Init(hash_type_);
   if (params.mode == BrotliParams::MODE_TEXT) {
-    StoreDictionaryWordHashes();
+    StoreDictionaryWordHashes(params.enable_transforms);
   }
 }
 
@@ -450,8 +450,8 @@ BrotliCompressor::~BrotliCompressor() {
 
 StaticDictionary *BrotliCompressor::static_dictionary_ = NULL;
 
-void BrotliCompressor::StoreDictionaryWordHashes() {
-  const int num_transforms = kNumTransforms;
+void BrotliCompressor::StoreDictionaryWordHashes(bool enable_transforms) {
+  const int num_transforms = enable_transforms ? kNumTransforms : 1;
   if (static_dictionary_ == NULL) {
     static_dictionary_ = new StaticDictionary;
     for (int t = num_transforms - 1; t >= 0; --t) {

--- a/enc/encode.h
+++ b/enc/encode.h
@@ -34,7 +34,9 @@ struct BrotliParams {
   };
   Mode mode;
 
-  BrotliParams() : mode(MODE_TEXT) {}
+  bool enable_transforms;
+
+  BrotliParams() : mode(MODE_TEXT), enable_transforms(false) {}
 };
 
 class BrotliCompressor {
@@ -64,7 +66,7 @@ class BrotliCompressor {
 
  private:
   // Initializes the hasher with the hashes of dictionary words.
-  void StoreDictionaryWordHashes();
+  void StoreDictionaryWordHashes(bool enable_transforms);
 
   BrotliParams params_;
   int window_bits_;


### PR DESCRIPTION
This change reduces the startup-time of the encoder considerably.
