### PR TITLE
[bro] fix missing malloc.h on OSX

### DIFF
--- a/tools/bro.cc
+++ b/tools/bro.cc
@@ -16,7 +16,11 @@
 */
 
 #include <fcntl.h>
-#include <malloc.h>
+#if defined(OS_MACOSX)
+  #include <malloc/malloc.h>
+#else
+  #include <malloc.h>
+#endif
 #include <stdio.h>
 #include <string>
 #include <sys/stat.h>


### PR DESCRIPTION
Hello,

the sample "bro" tool does not compile on OSX (I'm using 10.9.5):

```
bro.cc:19:10: fatal error: 'malloc.h' file not found
```

It seems like the malloc.h header file is located inside `/usr/include/malloc/malloc.h` on that platform.
With this patch, it compiles correctly.

All best,

Cosimo
