### PR TITLE
Fix undefined behavior in decoder.

### DIFF
--- a/dec/bit_reader.h
+++ b/dec/bit_reader.h
@@ -32,6 +32,7 @@ extern "C" {
 #define BROTLI_IBUF_MASK          (2 * BROTLI_READ_SIZE - 1)
 
 #define UNALIGNED_COPY64(dst, src) memcpy(dst, src, 8)
+#define UNALIGNED_MOVE64(dst, src) memmove(dst, src, 8)
 
 static const uint32_t kBitMask[BROTLI_MAX_NUM_BIT_READ] = {
   0, 1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767,

--- a/dec/decode.c
+++ b/dec/decode.c
@@ -532,7 +532,7 @@ static BROTLI_INLINE void IncrementalCopyFastPath(
     uint8_t* dst, const uint8_t* src, int len) {
   if (src < dst) {
     while (dst - src < 8) {
-      UNALIGNED_COPY64(dst, src);
+      UNALIGNED_MOVE64(dst, src);
       len -= (int)(dst - src);
       dst += dst - src;
     }


### PR DESCRIPTION
Use memmove() for copying overlapping buffers.
