### PR TITLE
Speed up FindMatchLength for non-x86 64-bit targets.

### DIFF
--- a/enc/find_match_length.h
+++ b/enc/find_match_length.h
@@ -25,8 +25,8 @@
 
 namespace brotli {
 
-// Separate implementation for x86_64, for speed.
-#if defined(__GNUC__) && defined(ARCH_K8)
+// Separate implementation for little-endian 64-bit targets, for speed.
+#if defined(__GNUC__) && defined(_LP64) && defined(IS_LITTLE_ENDIAN)
 
 static inline int FindMatchLengthWithLimit(const uint8_t* s1,
                                            const uint8_t* s2,


### PR DESCRIPTION
This CL enables 64-bit optimization for non-x86 target.