### PR TITLE
further fixes to allow compilation on MS Visual Studio 2010

### DIFF
--- a/enc/fast_log.h
+++ b/enc/fast_log.h
@@ -159,6 +159,13 @@ static const float kLog2Table[] = {
   7.9943534368588578f
 };
 
+#if defined(_MSC_VER) && _MSC_VER <= 1600
+// Calculates log2 of number (missing from MSC v.1600 required for Python bindings)
+inline double log2( double n ) {
+    return log( n ) / log( 2. );
+}
+#endif
+
 // Faster logarithm for small integers, with the property of log2(0) == 0.
 static inline double FastLog2(int v) {
   if (v < (int)(sizeof(kLog2Table) / sizeof(kLog2Table[0]))) {

--- a/enc/literal_cost.cc
+++ b/enc/literal_cost.cc
@@ -16,6 +16,10 @@
 
 #include "./literal_cost.h"
 
+#if defined(_MSC_VER) && _MSC_VER <= 1600
+#include "./fast_log.h"
+#endif
+
 #include <math.h>
 #include <stdint.h>
 #include <algorithm>

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,8 +21,9 @@ class BuildExt(build_ext):
 
         objects = []
         for lang, sources in (("c", c_sources), ("c++", cxx_sources)):
-            if lang == "c++":
-                extra_args.append("-std=c++0x")
+            if lang == "c++": 
+                if self.compiler.compiler_type in ["unix", "cygwin", "mingw32"]:
+                    extra_args.append("-std=c++0x")
 
             macros = ext.define_macros[:]
             if platform.system() == "Darwin":

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,6 +24,8 @@ class BuildExt(build_ext):
             if lang == "c++": 
                 if self.compiler.compiler_type in ["unix", "cygwin", "mingw32"]:
                     extra_args.append("-std=c++0x")
+                elif self.compiler.compiler_type == "msvc":
+                    extra_args.append("/EHsc")
 
             macros = ext.define_macros[:]
             if platform.system() == "Darwin":


### PR DESCRIPTION
Hello,

I don't like playing the Windows guy here, but there are still some unresolved issues with Microsoft's C++ compiler.

The recent patches by @szabadka ensured the Brotli encoder compiles successfully when using MS Visual Studio 2013.
However, the problem is that the latest Python for Windows (versions 3.3 and 3.4) are compiled with Visual Studio 2010.
Now, from what I understood, there's a requirement that Python extensions be linked to the same C runtime library which Python itself uses:

https://docs.python.org/3.4/extending/windows.html

If that's the case, then we must define a `log2` (binary logarithm) function, which unfortunately is not present in `math.h` from Visual C++  2010.
Here's my attempt, which seemingly doesn't break anything else, since I only redefine log2 if `_MSC_VER <= 1600`.

Through this patch, the Python extension can be built on Windows using the same compiler version used to build CPython itself.
Well, at least for Python 3.3 and 3.4... previous versions are still built with Visual Studio 2008, but I still had no luck with that.

Cheers,

C.