### PR TITLE
Fix encoder compilation error on MSVS 2010.

### DIFF
--- a/enc/fast_log.h
+++ b/enc/fast_log.h
@@ -164,7 +164,14 @@ static inline double FastLog2(int v) {
   if (v < (int)(sizeof(kLog2Table) / sizeof(kLog2Table[0]))) {
     return kLog2Table[v];
   }
+#if defined(_MSC_VER) && _MSC_VER <= 1600
+  // Visual Studio 2010 does not have the log2() function defined, so we use
+  // log() and a multiplication instead.
+  static const double kLog2Inv = 1.4426950408889634f;
+  return log(static_cast<double>(v)) * kLog2Inv;
+#else
   return log2(static_cast<double>(v));
+#endif
 }
 
 }  // namespace brotli

--- a/enc/literal_cost.cc
+++ b/enc/literal_cost.cc
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <algorithm>
 
+#include "./fast_log.h"
+
 namespace brotli {
 
 static int UTF8Position(int last, int c, int clamp) {
@@ -111,8 +113,7 @@ void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
     if (histo == 0) {
       histo = 1;
     }
-    float lit_cost = log2(static_cast<double>(in_window_utf8[utf8_pos])
-                          / histo);
+    float lit_cost = FastLog2(in_window_utf8[utf8_pos]) - FastLog2(histo);
     lit_cost += 0.02905;
     if (lit_cost < 1.0) {
       lit_cost *= 0.5;


### PR DESCRIPTION
As reported by @anthrotype, log2() is missing from MSVS 2010.
This patch uses log() and a multiplication in FastLog2()
for _MSV_VER <= 1600 and uses FastLog2() in literal_cost.cc
instead of log2().