### PR TITLE
Makefile fixes and cleanups

### DIFF
--- a/dec/Makefile
+++ b/dec/Makefile
@@ -2,7 +2,7 @@
 
 include ../shared.mk
 
-CPPFLAGS += -Wall
+CFLAGS += -Wall
 
 OBJS = bit_reader.o decode.o huffman.o safe_malloc.o streams.o
 

--- a/shared.mk
+++ b/shared.mk
@@ -1,19 +1,18 @@
 OS := $(shell uname)
 
-GFLAGS=-no-canonical-prefixes -fno-omit-frame-pointer -m64
-
-CPP = g++
-LFLAGS =
-CPPFLAGS = -c -std=c++0x $(GFLAGS)
+CC ?= gcc
+CXX ?= g++
 
 EMCC = emcc
 EMCCFLAGS = -O1 -W -Wall
 
+COMMON_FLAGS = -fno-omit-frame-pointer -no-canonical-prefixes
+
 ifeq ($(OS), Darwin)
   CPPFLAGS += -DOS_MACOSX
 else
-  CPPFLAGS += -fno-tree-vrp
+  COMMON_FLAGS += -fno-tree-vrp
 endif
 
-%.o : %.c
-	$(CPP) $(CPPFLAGS) $< -o $@
+CFLAGS += $(COMMON_FLAGS)
+CXXFLAGS += $(COMMON_FLAGS) -std=c++11

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,9 +11,9 @@ test: deps
 	./roundtrip_test.sh
 
 deps :
-	make -C $(BROTLI)/tools
+	$(MAKE) -C $(BROTLI)/tools
 
 clean :
 	rm -f testdata/*.{bro,unbro,uncompressed}
 	rm -f $(BROTLI)/{enc,dec,tools}/*.{un,}bro
-	make -C $(BROTLI)/tools clean
+	$(MAKE) -C $(BROTLI)/tools clean

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -13,13 +13,13 @@ EXE_OBJS=$(patsubst %, %.o, $(EXECUTABLES))
 all : $(EXECUTABLES)
 
 $(EXECUTABLES) : $(EXE_OBJS) deps
-	$(CPP) $(LFLAGS) $(ENCOBJ) $(DECOBJ) $@.o -o $@
+	$(CXX) $(LFLAGS) $(ENCOBJ) $(DECOBJ) $@.o -o $@
 
 deps :
-	make -C $(BROTLI)/dec
-	make -C $(BROTLI)/enc
+	$(MAKE) -C $(BROTLI)/dec
+	$(MAKE) -C $(BROTLI)/enc
 
 clean :
 	rm -f $(OBJS) $(EXE_OBJS) $(EXECUTABLES)
-	make -C $(BROTLI)/dec clean
-	make -C $(BROTLI)/enc clean
+	$(MAKE) -C $(BROTLI)/dec clean
+	$(MAKE) -C $(BROTLI)/enc clean


### PR DESCRIPTION
- Distinguish between CC/CFLAGS, CPP/CPPFLAGS and CXX/CXXFLAGS.
  Do not store compiler flags in CPPFLAGS, which is for preprocessor.
- Use COMMON_FLAGS for flags that are for both C and C++.
- Drop -m64 flag which is wrong on 32-bit systems.