### PR TITLE
[python] fix calling python script as subprocess on Windows

### DIFF
--- a/python/tests/compatibility_test.py
+++ b/python/tests/compatibility_test.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys
 import os
-from subprocess import call, Popen, PIPE
+from subprocess import check_call
 import filecmp
 
 
@@ -14,6 +14,7 @@ def diff_q(first_file, second_file):
     return 0
 
 
+PYTHON = sys.executable or "python"
 BRO = os.path.abspath("../bro.py")
 
 INPUTS = """\
@@ -42,15 +43,11 @@ for filename in INPUTS.splitlines():
     print('Testing decompression of file "%s"' % os.path.basename(filename))
     uncompressed = os.path.splitext(filename)[0] + ".uncompressed"
     expected = os.path.splitext(filename)[0]
-    call('"%s" -f -d -i "%s" -o "%s"' % (BRO, filename, uncompressed),
-         shell=True)
+    check_call([PYTHON, BRO, "-f", "-d", "-i", filename, "-o", uncompressed])
     if diff_q(uncompressed, expected) != 0:
         sys.exit(1)
     # Test the streaming version
-    with open(filename, "rb") as infile:
-        p = Popen('"%s" -d' % BRO, stdin=infile, stdout=PIPE, shell=True)
-    output = p.communicate()[0]
-    with open(uncompressed, "wb") as outfile:
-	    outfile.write(output)
+    with open(filename, "rb") as infile, open(uncompressed, "wb") as outfile:
+        check_call([PYTHON, BRO, '-d'], stdin=infile, stdout=outfile)
     if diff_q(uncompressed, expected) != 0:
         sys.exit(1)

--- a/python/tests/roundtrip_test.py
+++ b/python/tests/roundtrip_test.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import sys
 import os
-from subprocess import call, Popen, PIPE
+from subprocess import check_call, Popen, PIPE
 import filecmp
 
 
@@ -14,6 +14,7 @@ def diff_q(first_file, second_file):
     return 0
 
 
+PYTHON = sys.executable or "python"
 BRO = os.path.abspath("../bro.py")
 
 INPUTS = """\
@@ -33,18 +34,13 @@ for filename in INPUTS.splitlines():
     print('Roundtrip testing of file "%s"' % os.path.basename(filename))
     compressed = os.path.splitext(filename)[0] + ".bro"
     uncompressed = os.path.splitext(filename)[0] + ".unbro"
-    call('"%s" -f -i "%s" -o "%s"' % (BRO, filename, compressed), shell=True)
-    call('"%s" -f -d -i "%s" -o "%s"' %
-         (BRO, compressed, uncompressed), shell=True)
+    check_call([PYTHON, BRO, "-f", "-i", filename, "-o", compressed])
+    check_call([PYTHON, BRO, "-f", "-d", "-i", compressed, "-o", uncompressed])
     if diff_q(filename, uncompressed) != 0:
         sys.exit(1)
     # Test the streaming version
-    with open(filename, "rb") as infile:
-        p1 = Popen(BRO, stdin=infile, stdout=PIPE, shell=True)
-    p2 = Popen("%s -d" % BRO, stdin=p1.stdout, stdout=PIPE, shell=True)
-    p1.stdout.close()
-    output = p2.communicate()[0]
-    with open(uncompressed, "wb") as outfile:
-        outfile.write(output)
+    with open(filename, "rb") as infile, open(uncompressed, "wb") as outfile:
+        p = Popen([PYTHON, BRO], stdin=infile, stdout=PIPE)
+        check_call([PYTHON, BRO, "-d"], stdin=p.stdout, stdout=outfile)
     if diff_q(filename, uncompressed) != 0:
         sys.exit(1)


### PR DESCRIPTION
Hello,
This patch fixes an issue which occurs when calling a python script as a subprocess from within another python script on Windows.
Instead of executing the child script through the shell, I run it with the same `sys.executable` that was used to run the parent script.
Besides, I'm using `subprocess.check_call` instead of `subprocess.call` to halt execution if subprocess exits with non-zero return code.
Cheers,

Cosimo