### PR TITLE
Remove the redundant EncodeMetaBlockLength() function.

### DIFF
--- a/enc/brotli_bit_stream.cc
+++ b/enc/brotli_bit_stream.cc
@@ -55,7 +55,7 @@ void StoreVarLenUint8(int n, int* storage_ix, uint8_t* storage) {
 }
 
 bool StoreCompressedMetaBlockHeader(bool final_block,
-                                    int length,
+                                    size_t length,
                                     int* storage_ix,
                                     uint8_t* storage) {
   // Write ISLAST bit.
@@ -90,7 +90,7 @@ bool StoreCompressedMetaBlockHeader(bool final_block,
   return true;
 }
 
-bool StoreUncompressedMetaBlockHeader(int length,
+bool StoreUncompressedMetaBlockHeader(size_t length,
                                       int* storage_ix,
                                       uint8_t* storage) {
   // Write ISLAST bit. Uncompressed block cannot be the last one, so set to 0.

--- a/enc/brotli_bit_stream.h
+++ b/enc/brotli_bit_stream.h
@@ -38,12 +38,12 @@ void StoreVarLenUint8(int n, int* storage_ix, uint8_t* storage);
 
 // Stores the compressed meta-block header.
 bool StoreCompressedMetaBlockHeader(bool final_block,
-                                    int length,
+                                    size_t length,
                                     int* storage_ix,
                                     uint8_t* storage);
 
 // Stores the uncompressed meta-block header.
-bool StoreUncompressedMetaBlockHeader(int length,
+bool StoreUncompressedMetaBlockHeader(size_t length,
                                       int* storage_ix,
                                       uint8_t* storage);
 


### PR DESCRIPTION
Use Store{Compressed,Uncompressed}MetaBlockHeader() instead.