### PR TITLE
[bit_cost.h] fix "ambiguous call to overloaded function" (C2668)

### DIFF
--- a/enc/bit_cost.h
+++ b/enc/bit_cost.h
@@ -41,7 +41,7 @@ static inline double BitsEntropy(const int *population, int size) {
     sum += p;
     retval -= p * FastLog2(p);
   }
-  if (sum) retval -= sum * log(sum);
+  if (sum) retval -= sum * log(static_cast<double>(sum));
   if (retval < sum) {
     // At least one bit per literal is needed.
     retval = sum;


### PR DESCRIPTION
Hi,
after commit 534654def1f7b858e6f24f895609e51e19a19580, the encoder fails to compile on MS Visual Studio 2010, with the following error:

    c:\userslocal\cosimo.lupo\documents\github\brotli\enc\./bit_cost.h(44) : error C2668: 'log' : ambiguous call to overloaded function
        C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\INCLUDE\math.h(575): could be 'long double log(long double)'
        C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\INCLUDE\math.h(527): or       'float log(float)'
        C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\INCLUDE\math.h(120): or       'double log(double)'
        while trying to match the argument list '(int)'

At line 44 of "bit_cost.h", there is a call to `log` function: I think the varialbe `sum` should be cast to double.
Anyway, thanks for your work!

Cosimo
