### PR TITLE
Add quality and lgwin to the BrotliParams.

### DIFF
--- a/enc/ringbuffer.h
+++ b/enc/ringbuffer.h
@@ -20,6 +20,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "./port.h"
+
+namespace brotli {
+
 // A RingBuffer(window_bits, tail_bits) contains `1 << window_bits' bytes of
 // data in a circular manner: writing a byte writes it to
 // `position() % (1 << window_bits)'. For convenience, the RingBuffer array
@@ -28,9 +32,12 @@
 class RingBuffer {
  public:
   RingBuffer(int window_bits, int tail_bits)
-      : window_bits_(window_bits), tail_bits_(tail_bits), pos_(0) {
+      : window_bits_(window_bits),
+        mask_((1 << window_bits) - 1),
+        tail_size_(1 << tail_bits),
+        pos_(0) {
     static const int kSlackForFourByteHashingEverywhere = 3;
-    const int buflen = (1 << window_bits_) + (1 << tail_bits_);
+    const int buflen = (1 << window_bits_) + tail_size_;
     buffer_ = new uint8_t[buflen + kSlackForFourByteHashingEverywhere];
     for (int i = 0; i < kSlackForFourByteHashingEverywhere; ++i) {
       buffer_[buflen + i] = 0;
@@ -42,19 +49,18 @@ class RingBuffer {
 
   // Push bytes into the ring buffer.
   void Write(const uint8_t *bytes, size_t n) {
-    const size_t masked_pos = pos_ & ((1 << window_bits_) - 1);
+    const size_t masked_pos = pos_ & mask_;
     // The length of the writes is limited so that we do not need to worry
     // about a write
     WriteTail(bytes, n);
-    if (masked_pos + n <= (1 << window_bits_)) {
+    if (PREDICT_TRUE(masked_pos + n <= (1 << window_bits_))) {
       // A single write fits.
       memcpy(&buffer_[masked_pos], bytes, n);
     } else {
       // Split into two writes.
       // Copy into the end of the buffer, including the tail buffer.
       memcpy(&buffer_[masked_pos], bytes,
-             std::min(n,
-                      ((1 << window_bits_) + (1 << tail_bits_)) - masked_pos));
+             std::min(n, ((1 << window_bits_) + tail_size_) - masked_pos));
       // Copy into the begining of the buffer
       memcpy(&buffer_[0], bytes + ((1 << window_bits_) - masked_pos),
              n - ((1 << window_bits_) - masked_pos));
@@ -62,25 +68,33 @@ class RingBuffer {
     pos_ += n;
   }
 
+  void Reset() {
+    pos_ = 0;
+  }
+
   // Logical cursor position in the ring buffer.
   size_t position() const { return pos_; }
+
+  // Bit mask for getting the physical position for a logical position.
+  size_t mask() const { return mask_; }
 
   uint8_t *start() { return &buffer_[0]; }
   const uint8_t *start() const { return &buffer_[0]; }
 
  private:
   void WriteTail(const uint8_t *bytes, size_t n) {
-    const size_t masked_pos = pos_ & ((1 << window_bits_) - 1);
-    if (masked_pos < (1 << tail_bits_)) {
+    const size_t masked_pos = pos_ & mask_;
+    if (PREDICT_FALSE(masked_pos < tail_size_)) {
       // Just fill the tail buffer with the beginning data.
       const size_t p = (1 << window_bits_) + masked_pos;
-      memcpy(&buffer_[p], bytes, std::min(n, (1 << tail_bits_) - masked_pos));
+      memcpy(&buffer_[p], bytes, std::min(n, tail_size_ - masked_pos));
     }
   }
 
-  // Size of the ringbuffer is (1 << window_bits) + (1 << tail_bits).
+  // Size of the ringbuffer is (1 << window_bits) + tail_size_.
   const int window_bits_;
-  const int tail_bits_;
+  const size_t mask_;
+  const size_t tail_size_;
 
   // Position to write in the ring buffer.
   size_t pos_;
@@ -88,5 +102,7 @@ class RingBuffer {
   // as a tail.
   uint8_t *buffer_;
 };
+
+}  // namespace brotli
 
 #endif  // BROTLI_ENC_RINGBUFFER_H_


### PR DESCRIPTION
Remove the hard-coded constants for window size
and meta-block size.

Initialize internal storage for each metablock
separately and reserve only as much as needed
for the actual input.