### PR TITLE
Clean up some warnings in header files.

### DIFF
--- a/enc/hash.h
+++ b/enc/hash.h
@@ -220,12 +220,12 @@ class HashLongestMatchQuickly {
       uint32_t *bucket = buckets_ + key;
       prev_ix = *bucket++;
       for (int i = 0; i < kBucketSweep; ++i, prev_ix = *bucket++) {
-        const int backward = cur_ix - prev_ix;
+        const int backward_distance = cur_ix - prev_ix;
         prev_ix &= ring_buffer_mask;
         if (compare_char != ring_buffer[prev_ix + best_len]) {
           continue;
         }
-        if (PREDICT_FALSE(backward == 0 || backward > max_backward)) {
+        if (PREDICT_FALSE(backward_distance == 0 || backward_distance > max_backward)) {
           continue;
         }
         const int len =
@@ -234,13 +234,13 @@ class HashLongestMatchQuickly {
                                      max_length);
         if (len >= 4) {
           const double score = BackwardReferenceScore(average_cost,
-                                                      len, backward);
+                                                      len, backward_distance);
           if (best_score < score) {
             best_score = score;
             best_len = len;
             *best_len_out = best_len;
             *best_len_code_out = best_len;
-            *best_distance_out = backward;
+            *best_distance_out = backward_distance;
             *best_score_out = score;
             compare_char = ring_buffer[cur_ix_masked + best_len];
             match_found = true;

--- a/enc/ringbuffer.h
+++ b/enc/ringbuffer.h
@@ -53,7 +53,7 @@ class RingBuffer {
     // The length of the writes is limited so that we do not need to worry
     // about a write
     WriteTail(bytes, n);
-    if (PREDICT_TRUE(masked_pos + n <= (1 << window_bits_))) {
+    if (PREDICT_TRUE(masked_pos + n <= (1U << window_bits_))) {
       // A single write fits.
       memcpy(&buffer_[masked_pos], bytes, n);
     } else {

--- a/enc/static_dict.h
+++ b/enc/static_dict.h
@@ -53,10 +53,10 @@ class StaticDictionary {
     }
     map_[str] = ix;
     int v = 0;
-    for (int i = 0; i < 4 && i < str.size(); ++i) {
+    for (unsigned int i = 0; i < 4 && i < str.size(); ++i) {
       v += str[i] << (8 * i);
     }
-    if (prefix_map_[v] < str.size()) {
+    if (prefix_map_[v] < static_cast<int>(str.size())) {
       prefix_map_[v] = str.size();
     }
   }


### PR DESCRIPTION
These warnings are triggered when compiling with -Wshadow or
-Wsign-compare.  Since they are in header files they will also be
triggered in any project attempting to use brotli while compiling
with those warnings enabled.

For an example of these being triggered in an external project, see https://travis-ci.org/quixdb/squash/jobs/56952895#L790