### PR TITLE
[python] prepend build/lib folder to PYTHONPATH before running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 *.txt.uncompressed
 *.bro
 *.unbro
-/tools/bro
+tools/bro
+build/
+dist/

--- a/python/tests/compatibility_test.py
+++ b/python/tests/compatibility_test.py
@@ -2,33 +2,10 @@
 from __future__ import print_function
 import sys
 import os
-import sysconfig
 from subprocess import check_call
-import filecmp
 
+from test_utils import PYTHON, BRO, TEST_ENV, diff_q
 
-def diff_q(first_file, second_file):
-    """Simulate call to POSIX diff with -q argument"""
-    if not filecmp.cmp(first_file, second_file, shallow=False):
-        print("Files %s and %s differ" % (first_file, second_file))
-        return 1
-    return 0
-
-
-# prepend ../../build/lib folder to PYTHONPATH
-LIB_DIRNAME = "lib.{platform}-{version[0]}.{version[1]}".format(
-    platform=sysconfig.get_platform(),
-    version=sys.version_info)
-BUILD_PATH = os.path.abspath(os.path.join("..", "..", "build", LIB_DIRNAME))
-TEST_ENV = os.environ.copy()
-if 'PYTHONPATH' not in TEST_ENV:
-    TEST_ENV['PYTHONPATH'] = BUILD_PATH
-else:
-    TEST_ENV['PYTHONPATH'] = BUILD_PATH + os.pathsep + TEST_ENV['PYTHONPATH']
-
-
-PYTHON = sys.executable or "python"
-BRO = os.path.abspath("../bro.py")
 
 INPUTS = """\
 testdata/empty.compressed

--- a/python/tests/roundtrip_test.py
+++ b/python/tests/roundtrip_test.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import sys
 import os
+import sysconfig
 from subprocess import check_call, Popen, PIPE
 import filecmp
 
@@ -12,6 +13,18 @@ def diff_q(first_file, second_file):
         print("Files %s and %s differ" % (first_file, second_file))
         return 1
     return 0
+
+
+# prepend ../../build/lib folder to PYTHONPATH
+LIB_DIRNAME = "lib.{platform}-{version[0]}.{version[1]}".format(
+    platform=sysconfig.get_platform(),
+    version=sys.version_info)
+BUILD_PATH = os.path.abspath(os.path.join("..", "..", "build", LIB_DIRNAME))
+TEST_ENV = os.environ.copy()
+if 'PYTHONPATH' not in TEST_ENV:
+    TEST_ENV['PYTHONPATH'] = BUILD_PATH
+else:
+    TEST_ENV['PYTHONPATH'] = BUILD_PATH + os.pathsep + TEST_ENV['PYTHONPATH']
 
 
 PYTHON = sys.executable or "python"
@@ -34,13 +47,16 @@ for filename in INPUTS.splitlines():
     print('Roundtrip testing of file "%s"' % os.path.basename(filename))
     compressed = os.path.splitext(filename)[0] + ".bro"
     uncompressed = os.path.splitext(filename)[0] + ".unbro"
-    check_call([PYTHON, BRO, "-f", "-i", filename, "-o", compressed])
-    check_call([PYTHON, BRO, "-f", "-d", "-i", compressed, "-o", uncompressed])
+    check_call([PYTHON, BRO, "-f", "-i", filename, "-o", compressed],
+               env=TEST_ENV)
+    check_call([PYTHON, BRO, "-f", "-d", "-i", compressed, "-o", uncompressed],
+               env=TEST_ENV)
     if diff_q(filename, uncompressed) != 0:
         sys.exit(1)
     # Test the streaming version
     with open(filename, "rb") as infile, open(uncompressed, "wb") as outfile:
-        p = Popen([PYTHON, BRO], stdin=infile, stdout=PIPE)
-        check_call([PYTHON, BRO, "-d"], stdin=p.stdout, stdout=outfile)
+        p = Popen([PYTHON, BRO], stdin=infile, stdout=PIPE, env=TEST_ENV)
+        check_call([PYTHON, BRO, "-d"], stdin=p.stdout, stdout=outfile,
+                   env=TEST_ENV)
     if diff_q(filename, uncompressed) != 0:
         sys.exit(1)

--- a/python/tests/roundtrip_test.py
+++ b/python/tests/roundtrip_test.py
@@ -2,33 +2,10 @@
 from __future__ import print_function
 import sys
 import os
-import sysconfig
 from subprocess import check_call, Popen, PIPE
-import filecmp
 
+from test_utils import PYTHON, BRO, TEST_ENV, diff_q
 
-def diff_q(first_file, second_file):
-    """Simulate call to POSIX diff with -q argument"""
-    if not filecmp.cmp(first_file, second_file, shallow=False):
-        print("Files %s and %s differ" % (first_file, second_file))
-        return 1
-    return 0
-
-
-# prepend ../../build/lib folder to PYTHONPATH
-LIB_DIRNAME = "lib.{platform}-{version[0]}.{version[1]}".format(
-    platform=sysconfig.get_platform(),
-    version=sys.version_info)
-BUILD_PATH = os.path.abspath(os.path.join("..", "..", "build", LIB_DIRNAME))
-TEST_ENV = os.environ.copy()
-if 'PYTHONPATH' not in TEST_ENV:
-    TEST_ENV['PYTHONPATH'] = BUILD_PATH
-else:
-    TEST_ENV['PYTHONPATH'] = BUILD_PATH + os.pathsep + TEST_ENV['PYTHONPATH']
-
-
-PYTHON = sys.executable or "python"
-BRO = os.path.abspath("../bro.py")
 
 INPUTS = """\
 testdata/alice29.txt

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+import sys
+import os
+import sysconfig
+import filecmp
+
+
+def diff_q(first_file, second_file):
+    """Simulate call to POSIX diff with -q argument"""
+    if not filecmp.cmp(first_file, second_file, shallow=False):
+        print("Files %s and %s differ" % (first_file, second_file),
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+PYTHON = sys.executable or "python"
+
+# 'bro.py' script should be in parent directory
+BRO = os.path.abspath("../bro.py")
+
+# get platform- and version-specific build/lib folder
+platform_lib_name = "lib.{platform}-{version[0]}.{version[1]}".format(
+    platform=sysconfig.get_platform(),
+    version=sys.version_info)
+
+# by default, distutils' build base is in the same location as setup.py
+build_base = os.path.abspath(os.path.join("..", "..", "build"))
+build_lib = os.path.join(build_base, platform_lib_name)
+
+# prepend build/lib to PYTHONPATH environment variable
+TEST_ENV = os.environ.copy()
+if 'PYTHONPATH' not in TEST_ENV:
+    TEST_ENV['PYTHONPATH'] = build_lib
+else:
+    TEST_ENV['PYTHONPATH'] = build_lib + os.pathsep + TEST_ENV['PYTHONPATH']


### PR DESCRIPTION
this allows you to run `python setup.py test` without first having to install the extension.

    $ python setup.py build_ext
    $ python setup.py test

It assumes that the extension has was built in the default build base directory, i.e. `build/lib.{platform}-{version[0].version[1]}`.
I prepend the lib's path to the PYTHONPATH environment variable, and passes the latter to the subprocess running the tests.
Let me know if that was what you had in mind.

Cheers,

Cosimo