### PR TITLE
Add params to disable static dictionary and context modeling.

### DIFF
--- a/enc/backward_references.cc
+++ b/enc/backward_references.cc
@@ -65,7 +65,9 @@ void CreateBackwardReferences(size_t num_bytes,
     for (int k = position; k < position + num_bytes; ++k) {
       average_cost += literal_cost[k & literal_cost_mask];
     }
-    average_cost /= num_bytes;
+    if (num_bytes > 0) {
+      average_cost /= num_bytes;
+    }
   }
 
   // M1 match is for considering for two repeated copies, if moving

--- a/enc/block_splitter.h
+++ b/enc/block_splitter.h
@@ -51,17 +51,20 @@ struct BlockSplitIterator {
   int length_;
 };
 
-void CopyLiteralsToByteArray(const std::vector<Command>& cmds,
+void CopyLiteralsToByteArray(const Command* cmds,
+                             const size_t num_commands,
                              const uint8_t* data,
                              std::vector<uint8_t>* literals);
 
-void SplitBlock(const std::vector<Command>& cmds,
+void SplitBlock(const Command* cmds,
+                const size_t num_commands,
                 const uint8_t* data,
                 BlockSplit* literal_split,
                 BlockSplit* insert_and_copy_split,
                 BlockSplit* dist_split);
 
-void SplitBlockByTotalLength(const std::vector<Command>& all_commands,
+void SplitBlockByTotalLength(const Command* all_commands,
+                             const size_t num_commands,
                              int input_size,
                              int target_length,
                              std::vector<std::vector<Command> >* blocks);

--- a/enc/cluster.h
+++ b/enc/cluster.h
@@ -244,6 +244,22 @@ void HistogramReindex(std::vector<HistogramType>* out,
   }
 }
 
+template<typename HistogramType>
+void ClusterHistogramsTrivial(const std::vector<HistogramType>& in,
+                              int num_contexts, int num_blocks,
+                              int max_histograms,
+                              std::vector<HistogramType>* out,
+                              std::vector<int>* histogram_symbols) {
+  out->resize(num_blocks);
+  for (int i = 0; i < num_blocks; ++i) {
+    (*out)[i].Clear();
+    for (int j = 0; j < num_contexts; ++j) {
+      (*out)[i].AddHistogram(in[i * num_contexts + j]);
+      histogram_symbols->push_back(i);
+    }
+  }
+}
+
 // Clusters similar histograms in 'in' together, the selected histograms are
 // placed in 'out', and for each index in 'in', *histogram_symbols will
 // indicate which of the 'out' histograms is the best approximation.

--- a/enc/encode.h
+++ b/enc/encode.h
@@ -38,8 +38,10 @@ struct BrotliParams {
         quality(11),
         lgwin(22),
         lgblock(0),
+        enable_dictionary(true),
         enable_transforms(false),
-        greedy_block_split(false) {}
+        greedy_block_split(false),
+        enable_context_modeling(true) {}
 
   enum Mode {
     MODE_TEXT = 0,
@@ -56,8 +58,11 @@ struct BrotliParams {
   // If set to 0, the value will be set based on the quality.
   int lgblock;
 
+  // These settings will be respected only if quality > 9.
+  bool enable_dictionary;
   bool enable_transforms;
   bool greedy_block_split;
+  bool enable_context_modeling;
 };
 
 class BrotliCompressor {
@@ -100,7 +105,8 @@ class BrotliCompressor {
   int hash_type_;
   size_t input_pos_;
   std::unique_ptr<RingBuffer> ringbuffer_;
-  std::vector<float> literal_cost_;
+  std::unique_ptr<float[]> literal_cost_;
+  size_t literal_cost_mask_;
   int dist_cache_[4];
   uint8_t last_byte_;
   uint8_t last_byte_bits_;

--- a/enc/encode_parallel.cc
+++ b/enc/encode_parallel.cc
@@ -209,10 +209,11 @@ bool WriteMetaBlockParallel(const BrotliParams& params,
                               num_direct_distance_codes,
                               distance_postfix_bits);
     BuildMetaBlock(&input[0], input_pos, mask,
-                   commands,
+                   commands.data(), commands.size(),
                    num_direct_distance_codes,
                    distance_postfix_bits,
                    literal_context_mode,
+                   true,
                    &mb);
   }
 

--- a/enc/histogram.cc
+++ b/enc/histogram.cc
@@ -27,7 +27,8 @@
 namespace brotli {
 
 void BuildHistograms(
-    const std::vector<Command>& cmds,
+    const Command* cmds,
+    const size_t num_commands,
     const BlockSplit& literal_split,
     const BlockSplit& insert_and_copy_split,
     const BlockSplit& dist_split,
@@ -41,7 +42,7 @@ void BuildHistograms(
   BlockSplitIterator literal_it(literal_split);
   BlockSplitIterator insert_and_copy_it(insert_and_copy_split);
   BlockSplitIterator dist_it(dist_split);
-  for (int i = 0; i < cmds.size(); ++i) {
+  for (int i = 0; i < num_commands; ++i) {
     const Command &cmd = cmds[i];
     insert_and_copy_it.Next();
     (*insert_and_copy_histograms)[insert_and_copy_it.type_].Add(
@@ -66,7 +67,8 @@ void BuildHistograms(
 }
 
 void BuildLiteralHistogramsForBlockType(
-    const std::vector<Command>& cmds,
+    const Command* cmds,
+    const size_t num_commands,
     const BlockSplit& literal_split,
     const uint8_t* ringbuffer,
     size_t pos,
@@ -75,7 +77,7 @@ void BuildLiteralHistogramsForBlockType(
     int context_mode,
     std::vector<HistogramLiteral>* histograms) {
   BlockSplitIterator literal_it(literal_split);
-  for (int i = 0; i < cmds.size(); ++i) {
+  for (int i = 0; i < num_commands; ++i) {
     const Command &cmd = cmds[i];
     for (int j = 0; j < cmd.insert_len_; ++j) {
       literal_it.Next();

--- a/enc/histogram.h
+++ b/enc/histogram.h
@@ -87,7 +87,8 @@ static const int kLiteralContextBits = 6;
 static const int kDistanceContextBits = 2;
 
 void BuildHistograms(
-    const std::vector<Command>& cmds,
+    const Command* cmds,
+    const size_t num_commands,
     const BlockSplit& literal_split,
     const BlockSplit& insert_and_copy_split,
     const BlockSplit& dist_split,
@@ -100,7 +101,8 @@ void BuildHistograms(
     std::vector<HistogramDistance>* copy_dist_histograms);
 
 void BuildLiteralHistogramsForBlockType(
-    const std::vector<Command>& cmds,
+    const Command* cmds,
+    const size_t num_commands,
     const BlockSplit& literal_split,
     const uint8_t* ringbuffer,
     size_t pos,

--- a/enc/metablock.h
+++ b/enc/metablock.h
@@ -47,10 +47,12 @@ struct MetaBlockSplit {
 void BuildMetaBlock(const uint8_t* ringbuffer,
                     const size_t pos,
                     const size_t mask,
-                    const std::vector<Command>& cmds,
+                    const Command* cmds,
+                    size_t num_commands,
                     int num_direct_distance_codes,
                     int distance_postfix_bits,
                     int literal_context_mode,
+                    bool enable_context_modleing,
                     MetaBlockSplit* mb);
 
 void BuildMetaBlockGreedy(const uint8_t* ringbuffer,


### PR DESCRIPTION
Disable all slow features for quality <= 9 (literal cost modeling,
dictionary, context modeling, advanced block splitting).

Change vector<Command> arguments of internal functions
to Command* and size_t.