### PR TITLE
Encoder implementation using input/output classes.

### DIFF
--- a/enc/context.h
+++ b/enc/context.h
@@ -139,7 +139,7 @@ static const uint8_t kUTF8ContextLookup[512] = {
 };
 
 // Context lookup table for small signed integers.
-static const int kSigned3BitContextLookup[] = {
+static const uint8_t kSigned3BitContextLookup[] = {
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
   2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
   2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,


### PR DESCRIPTION
Add a BrotliCompress() method to the public encoder API
that uses the BrotliIn and BrotliOut classes and use
that in the 'bro' command-line tool.

Use the streaming api in BrotliCompressBuffer() and
BrotliCompressor::WriteMetaBlock().

Use the appropiate hashers for quality <= 9.