### PR TITLE
Remove the 'override' keyword from ~BrotliFileIn().

### DIFF
--- a/enc/streams.h
+++ b/enc/streams.h
@@ -103,7 +103,7 @@ class BrotliStringOut : public BrotliOut {
 class BrotliFileIn : public BrotliIn {
  public:
   BrotliFileIn(FILE* f, size_t max_read_size);
-  ~BrotliFileIn() override;
+  ~BrotliFileIn();
 
   const void* Read(size_t n, size_t* bytes_read) override;
 


### PR DESCRIPTION
Apparently MSVS 2010 does not support this.