### PR TITLE
Align distance code meaning in the brotli encoder.

### DIFF
--- a/enc/backward_references.cc
+++ b/enc/backward_references.cc
@@ -172,16 +172,17 @@ void CreateBackwardReferences(size_t num_bytes,
       apply_random_heuristics =
           i + 2 * best_len + random_heuristics_window_size;
       max_distance = std::min(i + i_diff, max_backward_limit);
-      int distance_code = best_dist + 16;
+      // The first 16 codes are special shortcodes, and the minimum offset is 1.
+      int distance_code = best_dist + 15;
       if (best_dist <= max_distance) {
         if (best_dist == dist_cache[0]) {
-          distance_code = 1;
+          distance_code = 0;
         } else if (best_dist == dist_cache[1]) {
-          distance_code = 2;
+          distance_code = 1;
         } else if (best_dist == dist_cache[2]) {
-          distance_code = 3;
+          distance_code = 2;
         } else if (best_dist == dist_cache[3]) {
-          distance_code = 4;
+          distance_code = 3;
         } else if (quality > 3 && best_dist >= 6) {
           for (int k = 4; k < kNumDistanceShortCodes; ++k) {
             int idx = kDistanceCacheIndex[k];
@@ -191,12 +192,12 @@ void CreateBackwardReferences(size_t num_bytes,
                                              11, 11, 11, 11,
                                              12, 12, 12, 12 };
             if (best_dist == candidate && best_dist >= kLimits[k]) {
-              distance_code = k + 1;
+              distance_code = k;
               break;
             }
           }
         }
-        if (distance_code > 1) {
+        if (distance_code > 0) {
           dist_cache[3] = dist_cache[2];
           dist_cache[2] = dist_cache[1];
           dist_cache[1] = dist_cache[0];

--- a/enc/command.h
+++ b/enc/command.h
@@ -24,7 +24,6 @@ namespace brotli {
 
 static inline void GetDistCode(int distance_code,
                                uint16_t* code, uint32_t* extra) {
-  distance_code -= 1;
   if (distance_code < 16) {
     *code = distance_code;
     *extra = 0;
@@ -106,6 +105,7 @@ static inline void GetLengthCode(int insertlen, int copylen, int distancecode,
 struct Command {
   Command() {}
 
+  // distance_code is e.g. 0 for same-as-last short code, or 16 for offset 1.
   Command(int insertlen, int copylen, int copylen_code, int distance_code)
       : insert_len_(insertlen), copy_len_(copylen) {
     GetDistCode(distance_code, &dist_prefix_, &dist_extra_);
@@ -120,12 +120,12 @@ struct Command {
 
   int DistanceCode() const {
     if (dist_prefix_ < 16) {
-      return dist_prefix_ + 1;
+      return dist_prefix_;
     }
     int nbits = dist_extra_ >> 24;
     int extra = dist_extra_ & 0xffffff;
     int prefix = dist_prefix_ - 12 - 2 * nbits;
-    return (prefix << nbits) + extra + 13;
+    return (prefix << nbits) + extra + 12;
   }
 
   int DistanceContext() const {

--- a/enc/prefix.h
+++ b/enc/prefix.h
@@ -62,7 +62,6 @@ inline void PrefixEncodeCopyDistance(int distance_code,
                                      int postfix_bits,
                                      uint16_t* code,
                                      uint32_t* extra_bits) {
-  distance_code -= 1;
   if (distance_code < kNumDistanceShortCodes + num_direct_codes) {
     *code = distance_code;
     *extra_bits = 0;


### PR DESCRIPTION
Two different definitions (offset by 1) were used in
command.h and hash.h. Now they have been made the same,
also consistent with the spec (e.g. 0 means use previous dist, etc...)