### PR TITLE
Support window bits 10 - 15 in the decoder.

### DIFF
--- a/docs/draft-alakuijala-brotli-03.nroff
+++ b/docs/draft-alakuijala-brotli-03.nroff
@@ -1356,9 +1356,31 @@ previous sections.
 The stream header has only the following one field:
 
 .nf
-   1-4 bits: WBITS, a value in the range 16 - 24, value 16 is
-             encoded with one 0 bit, and values 17 - 24 are
-             encoded with bit pattern xxx1 (so 0111 is 20)
+   1-7 bits: WBITS, a value in the range 10 - 24, encoded with
+             the following variable length code (as it appears in
+             the compressed data, where the bits are parsed from
+             right to left):
+
+                   Value    Bit Pattern
+                   -----    -----------
+                      10        0100001
+                      11        0110001
+                      12        1000001
+                      13        1010001
+                      14        1100001
+                      15        1110001
+                      16              0
+                      17        0000001
+                      18           0011
+                      19           0101
+                      20           0111
+                      21           1001
+                      22           1011
+                      23           1101
+                      24           1111
+
+             Note that bit pattern 0010001 is invalid and must not
+             be used.
 .fi
 
 The size of the sliding window, which is the maximum value of any

--- a/docs/draft-alakuijala-brotli-03.txt
+++ b/docs/draft-alakuijala-brotli-03.txt
@@ -86,15 +86,15 @@ Table of Contents
    8.  Static dictionary  . . . . . . . . . . . . . . . . . . . . . . 25
    9.  Compressed data format . . . . . . . . . . . . . . . . . . . . 27
       9.1.  Format of the stream header . . . . . . . . . . . . . . . 27
-      9.2.  Format of the meta-block header . . . . . . . . . . . . . 27
+      9.2.  Format of the meta-block header . . . . . . . . . . . . . 28
       9.3.  Format of the meta-block data . . . . . . . . . . . . . . 30
    10.  Decoding algorithm  . . . . . . . . . . . . . . . . . . . . . 31
    11.  Security Considerations . . . . . . . . . . . . . . . . . . . 33
-   12.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . 33
-   13.  Informative References  . . . . . . . . . . . . . . . . . . . 33
+   12.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . 34
+   13.  Informative References  . . . . . . . . . . . . . . . . . . . 34
    14.  Source code . . . . . . . . . . . . . . . . . . . . . . . . . 34
    Appendix A.  Static dictionary data  . . . . . . . . . . . . . . . 34
-   Appendix B.  List of word transformations . . . . . . . . . . . . 114
+   Appendix B.  List of word transformations . . . . . . . . . . . . 115
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . . 117
 
 
@@ -1478,13 +1478,43 @@ Internet-Draft                   Brotli                       April 2015
 
    The stream header has only the following one field:
 
-      1-4 bits: WBITS, a value in the range 16 - 24, value 16 is
-                encoded with one 0 bit, and values 17 - 24 are
-                encoded with bit pattern xxx1 (so 0111 is 20)
+      1-7 bits: WBITS, a value in the range 10 - 24, encoded with
+                the following variable length code (as it appears in
+                the compressed data, where the bits are parsed from
+                right to left):
+
+                      Value    Bit Pattern
+                      -----    -----------
+                         10        0100001
+                         11        0110001
+                         12        1000001
+                         13        1010001
+                         14        1100001
+                         15        1110001
+                         16              0
+                         17        0000001
+                         18           0011
+                         19           0101
+                         20           0111
+                         21           1001
+                         22           1011
+                         23           1101
+                         24           1111
+
+                Note that bit pattern 0010001 is invalid and must not
+                be used.
 
    The size of the sliding window, which is the maximum value of any
    non-dictionary reference backward distance, is given by the following
    formula:
+
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 27]
+
+Internet-Draft                   Brotli                       April 2015
+
 
       window size = (1 << WBITS) - 16
 
@@ -1508,14 +1538,6 @@ Internet-Draft                   Brotli                       April 2015
                  otherwise MNIBBLES is the value of this field plus 4.
                  If MNIBBLES is 0, the meta-block is empty, i.e. it does
                  not generate any uncompressed data. In this case, the
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 27]
-
-Internet-Draft                   Brotli                       April 2015
-
-
                  rest of the meta-block has the following format:
 
                     1 bit:  reserved, must be zero
@@ -1543,6 +1565,13 @@ Internet-Draft                   Brotli                       April 2015
                  nibble is all zeros, then the stream should be
                  rejected as invalid)
 
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 28]
+
+Internet-Draft                   Brotli                       April 2015
+
+
          1 bit:  ISUNCOMPRESSED, if set to 1, any bits of compressed
                  data up to the next byte boundary are ignored, and
                  the rest of the meta-block contains MLEN bytes of
@@ -1564,14 +1593,6 @@ Internet-Draft                   Brotli                       April 2015
                         9-16        xxx0111
                        17-32       xxxx1001
                        33-64      xxxxx1011
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 28]
-
-Internet-Draft                   Brotli                       April 2015
-
-
                        65-128    xxxxxx1101
                       129-256   xxxxxxx1111
 
@@ -1599,6 +1620,14 @@ Internet-Draft                   Brotli                       April 2015
       1-11 bits: NBLTYPESD, # of distance block types, encoded with
                  the same variable length code as above
 
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 29]
+
+Internet-Draft                   Brotli                       April 2015
+
+
          Prefix code over the block type code alphabet for distance
             block types, appears only if NBLTYPESD >= 2
 
@@ -1620,14 +1649,6 @@ Internet-Draft                   Brotli                       April 2015
                  the same variable length code as NBLTYPESL
 
          Literal context map, encoded as described in Paragraph 7.3,
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 29]
-
-Internet-Draft                   Brotli                       April 2015
-
-
             appears only if NTREESL >= 2, otherwise the context map
             has only zero values
 
@@ -1655,6 +1676,14 @@ Internet-Draft                   Brotli                       April 2015
 
          Block count code + Extra bits for next insert-and-copy
             block count, appears only if NBLTYPESI >= 2 and the
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 30]
+
+Internet-Draft                   Brotli                       April 2015
+
+
             previous insert-and-copy block count is zero
 
          Insert-and-copy length, encoded as in section 5, using the
@@ -1676,13 +1705,6 @@ Internet-Draft                   Brotli                       April 2015
                previous two bytes of the uncompressed data, the
                current literal block type, and the context map, as
                described in Paragraph 7.3.
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 30]
-
-Internet-Draft                   Brotli                       April 2015
-
 
          Block type code for next distance block type, appears only
            if NBLTYPESD >= 2 and the previous distance block count
@@ -1710,6 +1732,14 @@ Internet-Draft                   Brotli                       April 2015
       do
          read ISLAST bit
          if ISLAST
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 31]
+
+Internet-Draft                   Brotli                       April 2015
+
+
             read ISLASTEMPTY bit
             if ISLASTEMPTY
                break from loop
@@ -1732,14 +1762,6 @@ Internet-Draft                   Brotli                       April 2015
             read NBLTYPESi
             if NBLTYPESi >= 2
                read prefix code for block types, HTREE_BTYPE_i
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 31]
-
-Internet-Draft                   Brotli                       April 2015
-
-
                read prefix code for block counts, HTREE_BLEN_i
                read block count, BLEN_i
                set block type, BTYPE_i to 0
@@ -1766,6 +1788,14 @@ Internet-Draft                   Brotli                       April 2015
             if BLEN_I is zero
                read block type using HTREE_BTYPE_I and set BTYPE_I
                   save previous block type
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 32]
+
+Internet-Draft                   Brotli                       April 2015
+
+
                read block count using HTREE_BLEN_I and set BLEN_I
             decrement BLEN_I
             read insert and copy length, ILEN, CLEN with HTREEI[BTYPE_I]
@@ -1788,14 +1818,6 @@ Internet-Draft                   Brotli                       April 2015
                if BLEN_D is zero
                   read block type using HTREE_BTYPE_D and set BTYPE_D
                      save previous block type
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 32]
-
-Internet-Draft                   Brotli                       April 2015
-
-
                   read block count using HTREE_BLEN_D and set BLEN_D
                decrement BLEN_D
                compute context ID, CIDD from CLEN
@@ -1822,6 +1844,14 @@ Internet-Draft                   Brotli                       April 2015
 11. Security Considerations
 
    As with any compressed file formats, decompressor implementations
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 33]
+
+Internet-Draft                   Brotli                       April 2015
+
+
    should handle all compressed data byte sequences, not only those that
    conform to this specification, where non-conformant compressed data
    sequences should be discarded.  A possible attack against a system
@@ -1844,14 +1874,6 @@ Internet-Draft                   Brotli                       April 2015
 
    [LZ77]     Ziv J., Lempel A., "A Universal Algorithm for Sequential
               Data Compression", IEEE Transactions on Information
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 33]
-
-Internet-Draft                   Brotli                       April 2015
-
-
               Theory, Vol. 23, No. 3, pp. 337-343.
 
    [RFC1951]  Deutsch, P., "DEFLATE Compressed Data Format Specification
@@ -1878,6 +1900,14 @@ Appendix A. Static dictionary data
       74696d65646f776e6c6966656c6566746261636b636f64656461746173686f77
       6f6e6c7973697465636974796f70656e6a7573746c696b6566726565776f726b
       74657874796561726f766572626f64796c6f7665666f726d626f6f6b706c6179
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 34]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6c6976656c696e6568656c70686f6d65736964656d6f7265776f72646c6f6e67
       7468656d7669657766696e64706167656461797366756c6c686561647465726d
       656163686172656166726f6d747275656d61726b61626c6575706f6e68696768
@@ -1900,14 +1930,6 @@ Appendix A. Static dictionary data
       746875736461726b6361726466696c6566656172737461796b696c6c74686174
       66616c6c6175746f657665722e636f6d74616c6b73686f70766f746564656570
       6d6f6465726573747475726e626f726e62616e6466656c6c726f736575726c28
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 34]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       736b696e726f6c65636f6d6561637473616765736d656574676f6c642e6a7067
       6974656d7661727966656c747468656e73656e6464726f7056696577636f7079
       312e30223c2f613e73746f70656c73656c696573746f75727061636b2e676966
@@ -1934,6 +1956,14 @@ Internet-Draft                   Brotli                       April 2015
       666169726c61636b76657273706169726a756e6574656368696628217069636b
       6576696c242822237761726d6c6f7264646f657370756c6c2c30303069646561
       647261776875676573706f7466756e646275726e6872656663656c6c6b657973
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 35]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       7469636b686f75726c6f73736675656c31327078737569746465616c52535322
       6167656467726579474554226561736561696d736769726c616964733870783b
       6e617679677269647469707323393939776172736c61647963617273293b207d
@@ -1956,14 +1986,6 @@ Internet-Draft                   Brotli                       April 2015
       706f6c6c6e6f7661636f6c7367656e6520e28094736f6674726f6d6574696c6c
       726f73733c68333e706f75726661646570696e6b3c74723e6d696e69297c2128
       6d696e657a683ae862617273686561723030293b6d696c6b202d2d3e69726f6e
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 35]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       667265646469736b77656e74736f696c707574732f6a732f686f6c795432323a
       4953424e5432303a6164616d736565733c68323e6a736f6e272c2027636f6e74
       5432313a205253536c6f6f70617369616d6f6f6e3c2f703e736f756c4c494e45
@@ -1990,6 +2012,14 @@ Internet-Draft                   Brotli                       April 2015
       0d0a090962616e677472696d62617468297b0d0a303070780a7d293b6b6f3aec
       6665657361643e0d733a2f2f205b5d3b746f6c6c706c756728297b0a7b0d0a20
       2e6a7327323030706475616c626f61742e4a5047293b0a7d71756f74293b0a0a
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 36]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       27293b0a0d0a7d0d323031343230313532303136323031373230313832303139
       3230323032303231323032323230323332303234323032353230323632303237
       3230323832303239323033303230333132303332323033333230333432303335
@@ -2012,14 +2042,6 @@ Internet-Draft                   Brotli                       April 2015
       d182d0b0d0bdd0b5d0bfd0bed0bed182d0b8d0b7d0bdd0bed0b4d0bed182d0be
       d0b6d0b5d0bed0bdd0b8d185d09dd0b0d0b5d0b5d0b1d18bd0bcd18bd092d18b
       d181d0bed0b2d18bd0b2d0bed09dd0bed0bed0b1d09fd0bed0bbd0b8d0bdd0b8
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 36]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       d0a0d0a4d09dd0b5d09cd18bd182d18bd09ed0bdd0b8d0bcd0b4d0b0d097d0b0
       d094d0b0d09dd183d09ed0b1d182d0b5d098d0b7d0b5d0b9d0bdd183d0bcd0bc
       d0a2d18bd183d0b6d981d98ad8a3d986d985d8a7d985d8b9d983d984d8a3d988
@@ -2046,6 +2068,14 @@ Internet-Draft                   Brotli                       April 2015
       657773636865636b6c6567616c72697665726974656d73717569636b73686170
       6568756d616e6578697374676f696e676d6f7669657468697264626173696370
       65616365737461676577696474686c6f67696e696465617377726f7465706167
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 37]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       65737573657273647269766573746f7265627265616b736f757468766f696365
       73697465736d6f6e746877686572656275696c6477686963686561727468666f
       72756d746872656573706f72747061727479436c69636b6c6f7765726c697665
@@ -2068,14 +2098,6 @@ Internet-Draft                   Brotli                       April 2015
       74796c654c6f67696e68617070796f636375726c6566743a6672657368717569
       746566696c6d7367726164656e65656473757262616e66696768746261736973
       686f7665726175746f3b726f7574652e68746d6c6d6978656466696e616c596f
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 37]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       757220736c696465746f70696362726f776e616c6f6e65647261776e73706c69
       747265616368526967687464617465736d6172636871756f7465676f6f64734c
       696e6b73646f7562746173796e637468756d62616c6c6f776368696566796f75
@@ -2102,6 +2124,14 @@ Internet-Draft                   Brotli                       April 2015
       6e7470726f6f666272696566726f77223e67656e7265747275636b6c6f6f6b73
       56616c75654672616d652e6e65742f2d2d3e0a3c747279207b0a766172206d61
       6b6573636f737473706c61696e6164756c747175657374747261696e6c61626f
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 38]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       7268656c707363617573656d616769636d6f746f72746865697232353070786c
       656173747374657073436f756e74636f756c64676c617373736964657366756e
       6473686f74656c61776172646d6f7574686d6f76657370617269736769766573
@@ -2124,14 +2154,6 @@ Internet-Draft                   Brotli                       April 2015
       30253b636c75627373747566666269626c65766f74657320313030306b6f7265
       617d293b0d0a62616e647371756575653d207b7d3b383070783b636b696e677b
       0d0a09096168656164636c6f636b69726973686c696b6520726174696f737461
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 38]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       7473466f726d227961686f6f295b305d3b41626f757466696e64733c2f68313e
       64656275677461736b7355524c203d63656c6c737d2928293b313270783b7072
       696d6574656c6c737475726e7330783630302e6a706722737061696e62656163
@@ -2158,6 +2180,14 @@ Internet-Draft                   Brotli                       April 2015
       6e313370783b627269616e68656c6c6f73697a653d6f3d253246206a6f696e6d
       617962653c696d6720696d67223e2c20666a73696d67222022295b305d4d546f
       704254797065226e65776c7944616e736b637a656368747261696c6b6e6f7773
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 39]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       3c2f68353e666171223e7a682d636e3130293b0a2d3122293b747970653d626c
       7565737472756c7964617669732e6a73273b3e0d0a3c21737465656c20796f75
       2068323e0d0a666f726d206a6573757331303025206d656e752e0d0a090d0a77
@@ -2180,14 +2210,6 @@ Internet-Draft                   Brotli                       April 2015
       726f6775737461696775616c766f746f736361736f736775c3ad61707565646f
       736f6d6f73617669736f7573746564646562656e6e6f63686562757363616661
       6c74616575726f737365726965646963686f637572736f636c61766563617361
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 39]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       736c65c3b36e706c617a6f6c6172676f6f62726173766973746161706f796f6a
       756e746f7472617461766973746f637265617263616d706f68656d6f7363696e
       636f636172676f7069736f736f7264656e686163656ec3a1726561646973636f
@@ -2214,6 +2236,14 @@ Internet-Draft                   Brotli                       April 2015
       2671756f743b646f6d61696e636f6d6d6f6e7374617475736576656e74736d61
       7374657273797374656d616374696f6e62616e6e657272656d6f76657363726f
       6c6c757064617465676c6f62616c6d656469756d66696c7465726e756d626572
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 40]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6368616e6765726573756c747075626c696373637265656e63686f6f73656e6f
       726d616c74726176656c697373756573736f7572636574617267657473707269
       6e676d6f64756c656d6f62696c6573776974636870686f746f73626f72646572
@@ -2236,14 +2266,6 @@ Internet-Draft                   Brotli                       April 2015
       6163657364657669636573746174696363697469657373747265616d79656c6c
       6f7761747461636b737472656574666c6967687468696464656e696e666f223e
       6f70656e656475736566756c76616c6c65796361757365736c65616465727365
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 40]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       637265747365636f6e6464616d61676573706f72747365786365707472617469
       6e677369676e65647468696e67736566666563746669656c6473737461746573
       6f666669636576697375616c656469746f72766f6c756d655265706f72746d75
@@ -2270,6 +2292,14 @@ Internet-Draft                   Brotli                       April 2015
       4865616465722e7075736828636f75706c6567617264656e6272696467656c61
       756e636852657669657774616b696e67766973696f6e6c6974746c6564617469
       6e67427574746f6e6265617574797468656d6573666f72676f74536561726368
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 41]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       616e63686f72616c6d6f73746c6f616465644368616e676572657475726e7374
       72696e6772656c6f61644d6f62696c65696e636f6d65737570706c79536f7572
       63656f7264657273766965776564266e6273703b636f7572736541626f757420
@@ -2292,14 +2322,6 @@ Internet-Draft                   Brotli                       April 2015
       67686572666f72636564616e696d616c616e796f6e6541667269636161677265
       6564726563656e7450656f706c653c6272202f3e776f6e646572707269636573
       7475726e65647c7c207b7d3b6d61696e223e696e6c696e6573756e6461797772
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 41]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6170223e6661696c656463656e7375736d696e757465626561636f6e71756f74
       657331353070787c65737461746572656d6f7465656d61696c226c696e6b6564
       72696768743b7369676e616c666f726d616c312e68746d6c7369676e75707072
@@ -2326,6 +2348,14 @@ Internet-Draft                   Brotli                       April 2015
       657870657274696e6a75727977696474683d436f6f6b69655354415254206163
       726f73735f696d6167657468726561646e6174697665706f636b6574626f7822
       3e0a53797374656d20446176696463616e6365727461626c657370726f766564
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 42]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       417072696c207265616c6c796472697665726974656d223e6d6f7265223e626f
       61726473636f6c6f727363616d7075736669727374207c7c205b5d3b6d656469
       612e67756974617266696e69736877696474683a73686f7765644f7468657220
@@ -2348,14 +2378,6 @@ Internet-Draft                   Brotli                       April 2015
       80e4bd93e7b981e9ab94e4bfa1e681afe4b8ade59bbde68891e4bbace4b880e4
       b8aae585ace58fb8e7aea1e79086e8aebae59d9be58fafe4bba5e69c8de58aa1
       e697b6e997b4e4b8aae4babae4baa7e59381e887aae5b7b1e4bc81e4b89ae69f
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 42]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       a5e79c8be5b7a5e4bd9ce88194e7b3bbe6b2a1e69c89e7bd91e7ab99e68980e6
       9c89e8af84e8aebae4b8ade5bf83e69687e7aba0e794a8e688b7e9a696e9a1b5
       e4bd9ce88085e68a80e69cafe997aee9a298e79bb8e585b3e4b88be8bdbde690
@@ -2382,6 +2404,14 @@ Internet-Draft                   Brotli                       April 2015
       e5a4a7e5ada6e5ada6e4b9a0e59cb0e59d80e6b58fe8a788e68a95e8b584e5b7
       a5e7a88be8a681e6b182e6808ee4b988e697b6e58099e58a9fe883bde4b8bbe8
       a681e79baee5898de8b584e8aeafe59f8ee5b882e696b9e6b395e794b5e5bdb1
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 43]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       e68b9be88198e5a3b0e6988ee4bbbbe4bd95e581a5e5bab7e695b0e68daee7be
       8ee59bbde6b1bde8bda6e4bb8be7bb8de4bd86e698afe4baa4e6b581e7949fe4
       baa7e68980e4bba5e794b5e8af9de698bee7a4bae4b880e4ba9be58d95e4bd8d
@@ -2404,14 +2434,6 @@ Internet-Draft                   Brotli                       April 2015
       a5e69cace68f90e9ab98e58f91e8a880e696b9e99da2e59fbae98791e5a484e7
       9086e69d83e99990e5bdb1e78987e993b6e8a18ce8bf98e69c89e58886e4baab
       e789a9e59381e7bb8fe890a5e6b7bbe58aa0e4b893e5aeb6e8bf99e7a78de8af
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 43]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       9de9a298e8b5b7e69da5e4b89ae58aa1e585ace5918ae8aeb0e5bd95e7ae80e4
       bb8be8b4a8e9878fe794b7e4babae5bdb1e5938de5bc95e794a8e68aa5e5918a
       e983a8e58886e5bfabe9809fe592a8e8afa2e697b6e5b09ae6b3a8e6848fe794
@@ -2438,6 +2460,14 @@ Internet-Draft                   Brotli                       April 2015
       e5be97e588b0e982aee4bbb6e588b6e5baa6e9a39fe59381e899bde784b6e8bd
       ace8bdbde68aa5e4bbb7e8aeb0e88085e696b9e6a188e8a18ce694bfe4babae6
       b091e794a8e59381e4b89ce8a5bfe68f90e587bae98592e5ba97e784b6e5908e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 44]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       e4bb98e6acbee783ade782b9e4bba5e5898de5ae8ce585a8e58f91e5b896e8ae
       bee7bdaee9a286e5afbce5b7a5e4b89ae58cbbe999a2e79c8be79c8be7bb8fe5
       85b8e58e9fe59ba0e5b9b3e58fb0e59084e7a78de5a29ee58aa0e69d90e69699
@@ -2460,14 +2490,6 @@ Internet-Draft                   Brotli                       April 2015
       89e4ba9be8a487e8a3bde69687e5ada6e69cbae4bc9ae695b0e5ad97e8a385e4
       bfaee8b4ade789a9e5869ce69d91e585a8e99da2e7b2bee59381e585b6e5ae9e
       e4ba8be68385e6b0b4e5b9b3e68f90e7a4bae4b88ae5b882e8b0a2e8b0a2e699
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 44]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       aee9809ae69599e5b888e4b88ae4bca0e7b1bbe588abe6ad8ce69bb2e68ba5e6
       9c89e5889be696b0e9858de4bbb6e58faae8a681e697b6e4bba3e8b387e8a88a
       e8bebee588b0e4babae7949fe8aea2e99885e88081e5b888e5b195e7a4bae5bf
@@ -2494,6 +2516,14 @@ Internet-Draft                   Brotli                       April 2015
       e588abe4babae79b91e79da3e585b7e4bd93e4b896e7baaae59ba2e9989fe588
       9be4b89ae689bfe68b85e5a29ee995bfe69c89e4babae4bf9de68c81e59586e5
       aeb6e7bbb4e4bfaee58fb0e6b9bee5b7a6e58fb3e882a1e4bbbde7ad94e6a188
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 45]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       e5ae9ee99985e794b5e4bfa1e7bb8fe79086e7949fe591bde5aea3e4bca0e4bb
       bbe58aa1e6ada3e5bc8fe789b9e889b2e4b88be69da5e58d8fe4bc9ae58faae8
       83bde5bd93e784b6e9878de696b0e585a7e5aeb9e68c87e5afbce8bf90e8a18c
@@ -2516,14 +2546,6 @@ Internet-Draft                   Brotli                       April 2015
       94e5bd93e5be8be5b888e696b9e4bebfe6a0a1e59bade882a1e5b882e688bfe5
       b18be6a08fe79baee59198e5b7a5e5afbce887b4e7aa81e784b6e98193e585b7
       e69cace7bd91e7bb93e59088e6a1a3e6a188e58ab3e58aa8e58fa6e5a496e7be
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 45]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       8ee58583e5bc95e8b5b7e694b9e58f98e7acace59b9be4bc9ae8aea1e8aaaae6
       988ee99a90e7a781e5ae9de5ae9de8a784e88c83e6b688e8b4b9e585b1e5908c
       e5bf98e8aeb0e4bd93e7b3bbe5b8a6e69da5e5908de5ad97e799bce8a1a8e5bc
@@ -2550,6 +2572,14 @@ Internet-Draft                   Brotli                       April 2015
       e69c89e782b9e696b9e59091e585a8e696b0e4bfa1e794a8e8aebee696bde5bd
       a2e8b1a1e8b584e6a0bce7aa81e7a0b4e99a8fe79d80e9878de5a4a7e4ba8ee6
       98afe6af95e4b89ae699bae883bde58c96e5b7a5e5ae8ce7be8ee59586e59f8e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 46]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       e7bb9fe4b880e587bae78988e68993e980a0e794a2e59381e6a682e586b5e794
       a8e4ba8ee4bf9de79599e59ba0e7b4a0e4b8ade59c8be5ad98e582a8e8b4b4e5
       9bbee69c80e6849be995bfe69c9fe58fa3e4bbb7e79086e8b4a2e59fbae59cb0
@@ -2572,14 +2602,6 @@ Internet-Draft                   Brotli                       April 2015
       62c3ad6161676f73746f6e7565766f73756e69646f736361726c6f7365717569
       706f6e69c3b16f736d7563686f73616c67756e61636f7272656f696d6167656e
       7061727469726172726962616d6172c3ad61686f6d627265656d706c656f7665
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 46]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       7264616463616d62696f6d7563686173667565726f6e70617361646f6cc3ad6e
       65617061726563656e7565766173637572736f7365737461626171756965726f
       6c6962726f736375616e746f61636365736f6d696775656c766172696f736375
@@ -2606,6 +2628,14 @@ Internet-Draft                   Brotli                       April 2015
       d187d182d0bed0bad0b0d0bad0b8d0bbd0b8d18dd182d0bed0b2d181d0b5d0b5
       d0b3d0bed0bfd180d0b8d182d0b0d0bad0b5d189d0b5d183d0b6d0b5d09ad0b0
       d0bad0b1d0b5d0b7d0b1d18bd0bbd0bed0bdd0b8d092d181d0b5d0bfd0bed0b4
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 47]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       d0add182d0bed182d0bed0bcd187d0b5d0bcd0bdd0b5d182d0bbd0b5d182d180
       d0b0d0b7d0bed0bdd0b0d0b3d0b4d0b5d0bcd0bdd0b5d094d0bbd18fd09fd180
       d0b8d0bdd0b0d181d0bdd0b8d185d182d0b5d0bcd0bad182d0bed0b3d0bed0b4
@@ -2628,14 +2658,6 @@ Internet-Draft                   Brotli                       April 2015
       89e0a4b8e0a4aee0a587e0a495e0a4aee0a4b5e0a58be0a4b2e0a587e0a4b8e0
       a4ace0a4aee0a488e0a4a6e0a587e0a493e0a4b0e0a486e0a4aee0a4ace0a4b8
       e0a4ade0a4b0e0a4ace0a4a8e0a49ae0a4b2e0a4aee0a4a8e0a486e0a497e0a4
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 47]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       b8e0a580e0a4b2e0a580d8b9d984d989d8a5d984d989d987d8b0d8a7d8a2d8ae
       d8b1d8b9d8afd8afd8a7d984d989d987d8b0d987d8b5d988d8b1d8bad98ad8b1
       d983d8a7d986d988d984d8a7d8a8d98ad986d8b9d8b1d8b6d8b0d984d983d987
@@ -2662,6 +2684,14 @@ Internet-Draft                   Brotli                       April 2015
       70726f66696c657365727669636564656661756c7468696d73656c6664657461
       696c73636f6e74656e74737570706f7274737461727465646d65737361676573
       75636365737366617368696f6e3c7469746c653e636f756e7472796163636f75
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 48]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6e746372656174656473746f72696573726573756c747372756e6e696e677072
       6f6365737377726974696e676f626a6563747376697369626c6577656c636f6d
       6561727469636c65756e6b6e6f776e6e6574776f726b636f6d70616e7964796e
@@ -2684,14 +2714,6 @@ Internet-Draft                   Brotli                       April 2015
       6167655370616e69736867616c6c6572796465636c696e656d656574696e676d
       697373696f6e706f70756c61727175616c6974796d65617375726567656e6572
       616c7370656369657373657373696f6e73656374696f6e77726974657273636f
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 48]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       756e746572696e697469616c7265706f727473666967757265736d656d626572
       73686f6c64696e67646973707574656561726c69657265787072657373646967
       6974616c70696374757265416e6f746865726d61727269656474726166666963
@@ -2718,6 +2740,14 @@ Internet-Draft                   Brotli                       April 2015
       696c65206b696c6c696e6773686f77696e674974616c69616e64726f70706564
       68656176696c79656666656374732d31275d293b0a636f6e6669726d43757272
       656e74616476616e636573686172696e676f70656e696e6764726177696e6762
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 49]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       696c6c696f6e6f7264657265644765726d616e7972656c617465643c2f666f72
       6d3e696e636c75646577686574686572646566696e6564536369656e63656361
       74616c6f6741727469636c65627574746f6e736c617267657374756e69666f72
@@ -2740,14 +2770,6 @@ Internet-Draft                   Brotli                       April 2015
       65636f6e6f6d79526573756c747362726f74686572736f6c646965726c617267
       656c7963616c6c696e672e2671756f743b4163636f756e744564776172642073
       65676d656e74526f62657274206566666f727473506163696669636c6561726e
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 49]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6564757020776974686865696768743a77652068617665416e67656c65736e61
       74696f6e735f7365617263686170706c696564616371756972656d6173736976
       656772616e7465643a2066616c7365747265617465646269676765737462656e
@@ -2774,6 +2796,14 @@ Internet-Draft                   Brotli                       April 2015
       7461646f70746564707265706172656e65697468657267726561746c79677265
       617465726f766572616c6c696d70726f7665636f6d6d616e647370656369616c
       7365617263682e776f727368697066756e64696e6774686f7567687468696768
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 50]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       657374696e73746561647574696c6974797175617274657243756c7475726574
       657374696e67636c6561726c796578706f73656442726f777365726c69626572
       616c7d20636174636850726f6a6563746578616d706c656869646528293b466c
@@ -2796,14 +2826,6 @@ Internet-Draft                   Brotli                       April 2015
       68746d6c6d6f6e617263686f66662074686574656163686572686967686c7920
       62696f6c6f67796c696665206f666f72206576656e72697365206f6626726171
       756f3b706c75736f6e6568756e74696e672874686f756768446f75676c61736a
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 50]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6f696e696e67636972636c6573466f7220746865416e6369656e74566965746e
       616d76656869636c65737563682061736372797374616c76616c7565203d5769
       6e646f7773656e6a6f7965646120736d616c6c617373756d65643c612069643d
@@ -2830,6 +2852,14 @@ Internet-Draft                   Brotli                       April 2015
       6c756d6e73686f7573696e67736372697074736e65787420746f62656172696e
       676d617070696e67726576697365646a5175657279282d77696474683a746974
       6c65223e746f6f6c74697053656374696f6e64657369676e735475726b697368
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 51]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       796f756e6765722e6d61746368287d2928293b0a0a6275726e696e676f706572
       61746564656772656573736f757263653d52696368617264636c6f73656c7970
       6c6173746963656e74726965733c2f74723e0d0a636f6c6f723a23756c206964
@@ -2852,14 +2882,6 @@ Internet-Draft                   Brotli                       April 2015
       734d75736c696d7357686174206973696e206d616e796d61726b696e67726576
       65616c73496e646565642c657175616c6c792f73686f775f616f7574646f6f72
       657363617065284175737472696167656e6574696373797374656d2c496e2074
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 51]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       68652073697474696e67486520616c736f49736c616e647341636164656d790a
       09093c212d2d44616e69656c2062696e64696e67626c6f636b223e696d706f73
       65647574696c697a654162726168616d286578636570747b77696474683a7075
@@ -2886,6 +2908,14 @@ Internet-Draft                   Brotli                       April 2015
       65735669727475616c72657475726e73436f6d6d656e74506f7765726564696e
       6c696e653b706f76657274796368616d6265724c6976696e6720766f6c756d65
       73416e74686f6e796c6f67696e222052656c6174656445636f6e6f6d79726561
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 52]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6368657363757474696e67677261766974796c69666520696e43686170746572
       2d736861646f774e6f7461626c653c2f74643e0d0a2072657475726e73746164
       69756d7769646765747376617279696e6774726176656c7368656c6420627977
@@ -2908,14 +2938,6 @@ Internet-Draft                   Brotli                       April 2015
       6f73696e67636f6e7461696e496e73746561646669667465656e61732077656c
       6c2e7961686f6f2e726573706f6e64666967687465726f627363757265726566
       6c6563746f7267616e69633d204d6174682e65646974696e676f6e6c696e6520
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 52]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       70616464696e67612077686f6c656f6e6572726f7279656172206f66656e6420
       6f6620626172726965727768656e20697468656164657220686f6d65206f6672
       6573756d656472656e616d65647374726f6e673e68656174696e677265746169
@@ -2942,6 +2964,14 @@ Internet-Draft                   Brotli                       April 2015
       616e6b696e67686f6d6520746f6e616d696e67204172697a6f6e616372656469
       7473293b0a7d293b0a666f756e646572696e207475726e436f6c6c696e736265
       666f72652042757420746865636861726765645469746c65223e436170746169
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 53]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6e7370656c6c6564676f6464657373546167202d2d3e416464696e673a627574
       20776173526563656e742070617469656e746261636b20696e3d66616c736526
       4c696e636f6c6e7765206b6e6f77436f756e7465724a75646169736d73637269
@@ -2964,14 +2994,6 @@ Internet-Draft                   Brotli                       April 2015
       65737c7c7b7d3b7769776f726b206f6673796e6f6e796d646566656174736661
       766f7265646f70746963616c70616765547261756e6c6573732073656e64696e
       676c656674223e3c636f6d53636f72416c6c207468656a51756572792e746f75
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 53]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       72697374436c617373696366616c7365222057696c68656c6d73756275726273
       67656e75696e65626973686f70732e73706c697428676c6f62616c20666f6c6c
       6f7773626f6479206f666e6f6d696e616c436f6e74616374736563756c61726c
@@ -2998,6 +3020,14 @@ Internet-Draft                   Brotli                       April 2015
       616c6c706172746c79202d72696768743a4172616269616e6261636b65642063
       656e74757279756e6974206f666d6f62696c652d4575726f70652c697320686f
       6d657269736b206f6664657369726564436c696e746f6e636f7374206f666167
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 54]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       65206f66206265636f6d65206e6f6e65206f66702671756f743b4d6964646c65
       2065616427295b304372697469637373747564696f733e26636f70793b67726f
       7570223e617373656d626c6d616b696e6720707265737365647769646765742e
@@ -3020,14 +3050,6 @@ Internet-Draft                   Brotli                       April 2015
       7474703a2f2f20266e6273703b64726976657273657465726e616c73616d6520
       61736e6f7469636564766965776572737d2928293b0a206973206d6f72657365
       61736f6e73666f726d657220746865206e65776973206a757374636f6e73656e
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 54]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       742053656172636877617320746865776879207468657368697070656462723e
       3c62723e77696474683a206865696768743d6d616465206f6663756973696e65
       697320746861746120766572792041646d6972616c2066697865643b6e6f726d
@@ -3054,6 +3076,14 @@ Internet-Draft                   Brotli                       April 2015
       275d293b0d0a20206d61726b657477686f206973202822444f4d436f6d616e61
       6765646f6e6520666f72747970656f66204b696e67646f6d70726f6669747370
       726f706f7365746f2073686f7763656e7465723b6d6164652069746472657373
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 55]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       65647765726520696e6d6978747572657072656369736561726973696e677372
       63203d20276d616b652061207365637572656442617074697374766f74696e67
       200a0909766172204d61726368203267726577207570436c696d6174652e7265
@@ -3076,14 +3106,6 @@ Internet-Draft                   Brotli                       April 2015
       696e676d697373696c656c6f63616c6c79416761696e7374746865207761796b
       2671756f743b70783b223e0d0a707573686564206162616e646f6e6e756d6572
       616c4365727461696e496e20746869736d6f726520696e6f7220736f6d656e61
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 55]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6d65206973616e642c20696e63726f776e65644953424e20302d637265617465
       734f63746f6265726d6179206e6f7463656e746572206c61746520696e446566
       656e6365656e61637465647769736820746f62726f61646c79636f6f6c696e67
@@ -3110,6 +3132,14 @@ Internet-Draft                   Brotli                       April 2015
       6c6420616f6e636c69636b6120676976656e706f696e746572682671756f743b
       6576656e747320656c7365207b0a646974696f6e736e6f77207468652c207769
       7468206d616e2077686f6f72672f5765626f6e6520616e64636176616c727948
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 56]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       65206469656473656174746c6530302c303030207b77696e646f776861766520
       746f69662877696e64616e6420697473736f6c656c79206d2671756f743b7265
       6e65776564446574726f6974616d6f6e677374656974686572207468656d2069
@@ -3132,14 +3162,6 @@ Internet-Draft                   Brotli                       April 2015
       686967686572204f666669636520617265206e6f7774696d65732c207768656e
       20612070617920666f726f6e20746869732d6c696e6b223e3b626f7264657261
       726f756e6420616e6e75616c20746865204e6577707574207468652e636f6d22
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 56]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       2074616b696e20746f6120627269656628696e2074686567726f7570732e3b20
       7769647468656e7a796d657373696d706c6520696e206c6174657b7265747572
       6e746865726170796120706f696e7462616e6e696e67696e6b73223e0a28293b
@@ -3166,6 +3188,14 @@ Internet-Draft                   Brotli                       April 2015
       73616c67756e6f737061c3ad736573656a656d706c6f6465726563686f616465
       6dc3a1737072697661646f61677265676172656e6c61636573706f7369626c65
       686f74656c6573736576696c6c617072696d65726fc3ba6c74696d6f6576656e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 57]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       746f736172636869766f63756c747572616d756a65726573656e747261646161
       6e756e63696f656d626172676f6d65726361646f6772616e6465736573747564
       696f6d656a6f7265736665627265726f64697365c3b16f74757269736d6f63c3
@@ -3188,14 +3218,6 @@ Internet-Draft                   Brotli                       April 2015
       636f6d706c65746563616c656e646172706c6174666f726d61727469636c6573
       72657175697265646d6f76656d656e747175657374696f6e6275696c64696e67
       706f6c6974696373706f737369626c6572656c6967696f6e706879736963616c
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 57]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       666565646261636b7265676973746572706963747572657364697361626c6564
       70726f746f636f6c61756469656e636573657474696e67736163746976697479
       656c656d656e74736c6561726e696e67616e797468696e676162737472616374
@@ -3222,6 +3244,14 @@ Internet-Draft                   Brotli                       April 2015
       6461756768746572617574686f72222063756c747572616c66616d696c696573
       2f696d616765732f617373656d626c79706f77657266756c7465616368696e67
       66696e69736865646469737472696374637269746963616c6367692d62696e2f
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 58]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       707572706f7365737265717569726573656c656374696f6e6265636f6d696e67
       70726f766964657361636164656d6963657865726369736561637475616c6c79
       6d65646963696e65636f6e7374616e746163636964656e744d6167617a696e65
@@ -3244,14 +3274,6 @@ Internet-Draft                   Brotli                       April 2015
       446f776e6c6f6164776974686f7574207269676874223e0a6d65617375726573
       7769647468203d207661726961626c65696e766f6c76656476697267696e6961
       6e6f726d616c6c7968617070656e65646163636f756e74737374616e64696e67
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 58]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6e6174696f6e616c52656769737465727072657061726564636f6e74726f6c73
       6163637572617465626972746864617973747261746567796f6666696369616c
       67726170686963736372696d696e616c706f737369626c79636f6e73756d6572
@@ -3278,6 +3300,14 @@ Internet-Draft                   Brotli                       April 2015
       2e63737322202f3e20776562736974657265706f7274656464656661756c7422
       2f3e3c2f613e0d0a656c65637472696373636f746c616e646372656174696f6e
       7175616e746974792e204953424e2030646964206e6f7420696e7374616e6365
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 59]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2d7365617263682d22206c616e673d22737065616b657273436f6d7075746572
       636f6e7461696e7361726368697665736d696e69737465727265616374696f6e
       646973636f756e744974616c69616e6f63726974657269617374726f6e676c79
@@ -3300,14 +3330,6 @@ Internet-Draft                   Brotli                       April 2015
       6974656d70726f70656e67696e65657273656374696f6e7364657369676e6572
       70726f706f73616c3d2266616c73652245737061c3b16f6c72656c6561736573
       7375626d6974222065722671756f743b6164646974696f6e73796d70746f6d73
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 59]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6f7269656e7465647265736f757263657269676874223e3c706c656173757265
       73746174696f6e73686973746f72792e6c656176696e672020626f726465723d
       636f6e74656e747363656e746572223e2e0a0a536f6d65206469726563746564
@@ -3334,6 +3356,14 @@ Internet-Draft                   Brotli                       April 2015
       636f6e73696465727669736974696e676578706c6f7265727072696d61727920
       7365617263682220616e64726f696422717569636b6c79206d656574696e6773
       657374696d6174653b72657475726e203b636f6c6f723a23206865696768743d
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 60]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       617070726f76616c2c202671756f743b20636865636b65642e6d696e2e6a7322
       6d61676e657469633e3c2f613e3c2f68666f7265636173742e205768696c6520
       74687572736461796476657274697365266561637574653b686173436c617373
@@ -3356,14 +3386,6 @@ Internet-Draft                   Brotli                       April 2015
       3c73656374696f6e66696e64696e6773726f6c6520696e20706f70756c617220
       204f63746f62657277656273697465206578706f737572657573656420746f20
       206368616e6765736f70657261746564636c69636b696e67656e746572696e67
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 60]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       636f6d6d616e6473696e666f726d6564206e756d6265727320203c2f6469763e
       6372656174696e676f6e5375626d69746d6172796c616e64636f6c6c65676573
       616e616c797469636c697374696e6773636f6e746163742e6c6f67676564496e
@@ -3390,6 +3412,14 @@ Internet-Draft                   Brotli                       April 2015
       696d7072696d69726d69656e74726173616dc3a97269636176656e6465646f72
       736f636965646164726573706563746f7265616c697a6172726567697374726f
       70616c6162726173696e746572c3a973656e746f6e636573657370656369616c
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 61]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6d69656d62726f737265616c6964616463c3b372646f62617a617261676f7a61
       70c3a167696e6173736f6369616c6573626c6f71756561726765737469c3b36e
       616c7175696c657273697374656d61736369656e63696173636f6d706c65746f
@@ -3412,14 +3442,6 @@ Internet-Draft                   Brotli                       April 2015
       6c6963656e636961636f6e73756c74616173706563746f736372c3ad74696361
       64c3b36c617265736a757374696369616465626572c3a16e706572c3ad6f646f
       6e656365736974616d616e74656e65727065717565c3b16f7265636962696461
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 61]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       74726962756e616c74656e657269666563616e6369c3b36e63616e6172696173
       64657363617267616469766572736f736d616c6c6f7263617265717569657265
       74c3a9636e69636f6465626572c3ad6176697669656e646166696e616e7a6173
@@ -3446,6 +3468,14 @@ Internet-Draft                   Brotli                       April 2015
       d0b2d18bd188d0b5d0bdd0b0d0bcd0b8d182d0b8d0bfd0b0d182d0bed0bcd183
       d0bfd180d0b0d0b2d0bbd0b8d186d0b0d0bed0b4d0bdd0b0d0b3d0bed0b4d18b
       d0b7d0bdd0b0d18ed0bcd0bed0b3d183d0b4d180d183d0b3d0b2d181d0b5d0b9
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 62]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       d0b8d0b4d0b5d182d0bad0b8d0bdd0bed0bed0b4d0bdd0bed0b4d0b5d0bbd0b0
       d0b4d0b5d0bbd0b5d181d180d0bed0bad0b8d18ed0bdd18fd0b2d0b5d181d18c
       d095d181d182d18cd180d0b0d0b7d0b0d0bdd0b0d188d0b8d8a7d984d984d987
@@ -3468,14 +3498,6 @@ Internet-Draft                   Brotli                       April 2015
       d981d8b1d98ad982d983d8aad8a8d8aad8a3d981d8b6d984d985d8b7d8a8d8ae
       d8a7d983d8abd8b1d8a8d8a7d8b1d983d8a7d981d8b6d984d8a7d8add984d989
       d986d981d8b3d987d8a3d98ad8a7d985d8b1d8afd988d8afd8a3d986d987d8a7
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 62]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       d8afd98ad986d8a7d8a7d984d8a7d986d985d8b9d8b1d8b6d8aad8b9d984d985
       d8afd8a7d8aed984d985d985d983d98600000000000000000100010001000100
       0200020002000200040004000400040000010203040506070706050403020100
@@ -3502,6 +3524,14 @@ Internet-Draft                   Brotli                       April 2015
       65696e666c75656e636526726171756f3b3c2f65666665637469766567656e65
       72616c6c797472616e73666f726d62656175746966756c7472616e73706f7274
       6f7267616e697a65647075626c697368656470726f6d696e656e74756e74696c
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 63]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       207468657468756d626e61696c4e6174696f6e616c202e666f63757328293b6f
       76657220746865206d6967726174696f6e616e6e6f756e636564666f6f746572
       223e0a657863657074696f6e6c657373207468616e657870656e73697665666f
@@ -3524,14 +3554,6 @@ Internet-Draft                   Brotli                       April 2015
       656c6174696f6e734e6f74652074686174656666696369656e74706572666f72
       6d656474776f20796561727353696e6365207468657468657265666f72657772
       6170706572223e616c7465726e617465696e63726561736564426174746c6520
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 63]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6f66706572636569766564747279696e6720746f6e6563657373617279706f72
       747261796564656c656374696f6e73456c697a61626574683c2f696672616d65
       3e646973636f76657279696e737572616e6365732e6c656e6774683b6c656765
@@ -3558,6 +3580,14 @@ Internet-Draft                   Brotli                       April 2015
       206e6f7463656e7475726965734a6170616e65736520616d6f6e672074686563
       6f6d706c65746564616c676f726974686d696e74657265737473726562656c6c
       696f6e756e646566696e6564656e636f7572616765726573697a61626c65696e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 64]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       766f6c76696e6773656e736974697665756e6976657273616c70726f76697369
       6f6e28616c74686f756768666561747572696e67636f6e647563746564292c20
       776869636820636f6e74696e7565642d686561646572223e4665627275617279
@@ -3580,14 +3610,6 @@ Internet-Draft                   Brotli                       April 2015
       656477657265206d616465656d6f74696f6e616c656d657267656e63796e6172
       7261746976656164766f636174657370783b626f72646572636f6d6d69747465
       646469723d226c747222656d706c6f7965657372657365617263682e2073656c
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 64]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6563746564737563636573736f72637573746f6d657273646973706c61796564
       53657074656d626572616464436c6173732846616365626f6f6b207375676765
       73746564616e64206c617465726f7065726174696e67656c61626f7261746553
@@ -3614,6 +3636,14 @@ Internet-Draft                   Brotli                       April 2015
       627374616e63656175746f6d61746963617370656374206f66416d6f6e672074
       6865636f6e6e6563746564657374696d6174657341697220466f726365737973
       74656d206f666f626a656374697665696d6d6564696174656d616b696e672069
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 65]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       747061696e74696e6773636f6e717565726564617265207374696c6c70726f63
       656475726567726f777468206f666865616465642062794575726f7065616e20
       6469766973696f6e736d6f6c6563756c65736672616e6368697365696e74656e
@@ -3636,14 +3666,6 @@ Internet-Draft                   Brotli                       April 2015
       7a75656c6128666f726d65726c79746865207374617465706572736f6e6e656c
       7374726174656769636661766f7572206f66696e76656e74696f6e57696b6970
       65646961636f6e74696e656e747669727475616c6c7977686963682077617370
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 65]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       72696e6369706c65436f6d706c657465206964656e746963616c73686f772074
       6861747072696d6974697665617761792066726f6d6d6f6c6563756c61727072
       65636973656c79646973736f6c766564556e6465722074686576657273696f6e
@@ -3670,6 +3692,14 @@ Internet-Draft                   Brotli                       April 2015
       703c6469762069643d227269676874223e0d0a7265736964656e63656c656176
       6520746865636f6e74656e74223e617265206f6674656e20207d2928293b0d0a
       70726f6261626c792050726f666573736f722d627574746f6e2220726573706f
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 66]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6e64656473617973207468617468616420746f206265706c6163656420696e48
       756e67617269616e737461747573206f66736572766573206173556e69766572
       73616c657865637574696f6e616767726567617465666f72207768696368696e
@@ -3692,14 +3722,6 @@ Internet-Draft                   Brotli                       April 2015
       686f696365206f667468652073616d6520737065636966696320627573696e65
       7373205468652066697273742e6c656e6774683b2064657369726520746f6465
       616c207769746873696e636520746865757365724167656e74636f6e63656976
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 66]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6564696e6465782e7068706173202671756f743b656e6761676520696e726563
       656e746c792c6665772079656172737765726520616c736f0a3c686561643e0a
       3c656469746564206279617265206b6e6f776e63697469657320696e61636365
@@ -3726,6 +3748,14 @@ Internet-Draft                   Brotli                       April 2015
       6c696e6764657369676e206f666d616b6573207468656d756368206c65737341
       6d65726963616e732e0a0a4166746572202c20627574207468654d757365756d
       206f666c6f75697369616e612866726f6d207468656d696e6e65736f74617061
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 67]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       727469636c6573612070726f63657373446f6d696e6963616e766f6c756d6520
       6f6672657475726e696e67646566656e73697665303070787c726967686d6164
       652066726f6d6d6f7573656f76657222207374796c653d22737461746573206f
@@ -3748,14 +3778,6 @@ Internet-Draft                   Brotli                       April 2015
       99a8e4ba92e88194e7bd91e688bfe59cb0e4baa7e4bfb1e4b990e983a8e587ba
       e78988e7a4bee68e92e8a18ce6a69ce983a8e890bde6a0bce8bf9be4b880e6ad
       a5e694afe4bb98e5ae9de9aa8ce8af81e7a081e5a794e59198e4bc9ae695b0e6
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 67]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       8daee5ba93e6b688e8b4b9e88085e58a9ee585ace5aea4e8aea8e8aebae58cba
       e6b7b1e59cb3e5b882e692ade694bee599a8e58c97e4baace5b882e5a4a7e5ad
       a6e7949fe8b68ae69da5e8b68ae7aea1e79086e59198e4bfa1e681afe7bd9173
@@ -3782,6 +3804,14 @@ Internet-Draft                   Brotli                       April 2015
       a9636e696361736f626a657469766f73636f6e746163746f73e0a4aee0a587e0
       a482e0a4b2e0a4bfe0a48fe0a4b9e0a588e0a482e0a497e0a4afe0a4bee0a4b8
       e0a4bee0a4a5e0a48fe0a4b5e0a482e0a4b0e0a4b9e0a587e0a495e0a58be0a4
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 68]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       88e0a495e0a581e0a49be0a4b0e0a4b9e0a4bee0a4ace0a4bee0a4a6e0a495e0
       a4b9e0a4bee0a4b8e0a4ade0a580e0a4b9e0a581e0a48fe0a4b0e0a4b9e0a580
       e0a4aee0a588e0a482e0a4a6e0a4bfe0a4a8e0a4ace0a4bee0a4a46469706c6f
@@ -3804,14 +3834,6 @@ Internet-Draft                   Brotli                       April 2015
       a4a8e0a4bee0a4b9e0a582e0a482e0a4b2e0a4bee0a496e0a49ce0a580e0a4a4
       e0a4ace0a49fe0a4a8e0a4aee0a4bfe0a4b2e0a487e0a4b8e0a587e0a486e0a4
       a8e0a587e0a4a8e0a4afe0a4bee0a495e0a581e0a4b2e0a4b2e0a589e0a497e0
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 68]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       a4ade0a4bee0a497e0a4b0e0a587e0a4b2e0a49ce0a497e0a4b9e0a4b0e0a4be
       e0a4aee0a4b2e0a497e0a587e0a4aae0a587e0a49ce0a4b9e0a4bee0a4a5e0a4
       87e0a4b8e0a580e0a4b8e0a4b9e0a580e0a495e0a4b2e0a4bee0a4a0e0a580e0
@@ -3838,6 +3860,14 @@ Internet-Draft                   Brotli                       April 2015
       66696e6974696f6e6c656164657273686970546563686e6f6c6f67795061726c
       69616d656e74636f6d70617269736f6e756c20636c6173733d222e696e646578
       4f662822636f6e636c7573696f6e64697363757373696f6e636f6d706f6e656e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 69]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       747362696f6c6f676963616c5265766f6c7574696f6e5f636f6e7461696e6572
       756e64657273746f6f646e6f7363726970743e3c7065726d697373696f6e6561
       6368206f7468657261746d6f737068657265206f6e666f6375733d223c666f72
@@ -3860,14 +3890,6 @@ Internet-Draft                   Brotli                       April 2015
       636b3d22636f6e736964657265646465706172746d656e746f63637570617469
       6f6e736f6f6e206166746572696e766573746d656e7470726f6e6f756e636564
       6964656e7469666965646578706572696d656e744d616e6167656d656e746765
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 69]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6f6772617068696322206865696768743d226c696e6b2072656c3d222e726570
       6c616365282f64657072657373696f6e636f6e666572656e636570756e697368
       6d656e74656c696d696e61746564726573697374616e63656164617074617469
@@ -3894,6 +3916,14 @@ Internet-Draft                   Brotli                       April 2015
       2f2f64696374696f6e61727970657263657074696f6e7265766f6c7574696f6e
       666f756e646174696f6e70783b6865696768743a7375636365737366756c7375
       70706f72746572736d696c6c656e6e69756d6869732066617468657274686520
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 70]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2671756f743b6e6f2d7265706561743b636f6d6d65726369616c696e64757374
       7269616c656e636f757261676564616d6f756e74206f6620756e6f6666696369
       616c656666696369656e63795265666572656e636573636f6f7264696e617465
@@ -3916,14 +3946,6 @@ Internet-Draft                   Brotli                       April 2015
       65206c61747465723c2f666f726d3e0a3c2f2e696e6465784f66282769203d20
       303b2069203c646966666572656e63656465766f74656420746f747261646974
       696f6e7373656172636820666f72756c74696d6174656c79746f75726e616d65
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 70]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6e7461747472696275746573736f2d63616c6c6564207d0a3c2f7374796c653e
       6576616c756174696f6e656d70686173697a656461636365737369626c653c2f
       73656374696f6e3e73756363657373696f6e616c6f6e6720776974684d65616e
@@ -3950,6 +3972,14 @@ Internet-Draft                   Brotli                       April 2015
       72616c69616e4f726967696e616c6c797265666572656e6365730a3c2f686561
       643e0d0a7265636f676e69736564696e697469616c697a656c696d6974656420
       746f416c6578616e647269617265746972656d656e74416476656e7475726573
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 71]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       666f75722079656172730a0a266c743b212d2d20696e6372656173696e676465
       636f726174696f6e683320636c6173733d226f726967696e73206f666f626c69
       676174696f6e726567756c6174696f6e636c61737369666965642866756e6374
@@ -3972,14 +4002,6 @@ Internet-Draft                   Brotli                       April 2015
       6f6e6c6920636c6173733d22536369656e7469666963636c6173733d226e6f2d
       74726164656d61726b736d6f7265207468616e20776964657370726561644c69
       6265726174696f6e746f6f6b20706c616365646179206f66207468656173206c
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 71]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6f6e67206173696d707269736f6e65644164646974696f6e616c0a3c68656164
       3e0a3c6d4c61626f7261746f72794e6f76656d6265722032657863657074696f
       6e73496e647573747269616c76617269657479206f66666c6f61743a206c6566
@@ -4006,6 +4028,14 @@ Internet-Draft                   Brotli                       April 2015
       5068696c6f736f706879667269656e64736869706c656164696e6720746f6769
       76696e6720746865746f776172642074686567756172616e74656564646f6375
       6d656e746564636f6c6f723a23303030766964656f2067616d65636f6d6d6973
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 72]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       73696f6e7265666c656374696e676368616e6765207468656173736f63696174
       656473616e732d73657269666f6e6b657970726573733b2070616464696e673a
       48652077617320746865756e6465726c79696e677479706963616c6c79202c20
@@ -4028,14 +4058,6 @@ Internet-Draft                   Brotli                       April 2015
       6420746861747374796c6573686565746d616e757363726970747374616e6473
       20666f72206e6f2d72657065617428736f6d6574696d6573436f6d6d65726369
       616c696e20416d6572696361756e64657274616b656e71756172746572206f66
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 72]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       616e206578616d706c65706572736f6e616c6c79696e6465782e7068703f3c2f
       627574746f6e3e0a70657263656e74616765626573742d6b6e6f776e63726561
       74696e67206122206469723d226c74724c69657574656e616e740a3c64697620
@@ -4062,6 +4084,14 @@ Internet-Draft                   Brotli                       April 2015
       74686174696e672671756f743b2076616c69676e3d746f70746865204765726d
       616e6f757473696465206f666e65676f74696174656468697320636172656572
       73657061726174696f6e69643d227365617263687761732063616c6c65647468
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 73]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6520666f7572746872656372656174696f6e6f74686572207468616e70726576
       656e74696f6e7768696c652074686520656475636174696f6e2c636f6e6e6563
       74696e6761636375726174656c7977657265206275696c74776173206b696c6c
@@ -4084,14 +4114,6 @@ Internet-Draft                   Brotli                       April 2015
       72616e67652066726f6d70757273756974206f66666f6c6c6f77207468656272
       6f7567687420746f696e20456e676c616e646167726565207468617461636375
       736564206f66636f6d65732066726f6d70726576656e74696e67646976207374
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 73]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       796c653d686973206f72206865727472656d656e646f757366726565646f6d20
       6f66636f6e6365726e696e67302031656d2031656d3b4261736b657462616c6c
       2f7374796c652e637373616e206561726c6965726576656e2061667465722f22
@@ -4118,6 +4140,14 @@ Internet-Draft                   Brotli                       April 2015
       70656369616c6573646973706f6e69626c6561637475616c6964616472656665
       72656e63696176616c6c61646f6c69646269626c696f7465636172656c616369
       6f6e657363616c656e646172696f706f6cc3ad7469636173616e746572696f72
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 74]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6573646f63756d656e746f736e61747572616c657a616d6174657269616c6573
       6469666572656e63696165636f6ec3b36d6963617472616e73706f727465726f
       6472c3ad6775657a70617274696369706172656e6375656e7472616e64697363
@@ -4140,14 +4170,6 @@ Internet-Draft                   Brotli                       April 2015
       d0b5d0b5d187d0b8d181d0bbd0b5d0bdd0bed0b2d18bd0b5d183d181d0bbd183
       d0b3d0bed0bad0bed0bbd0bed0bdd0b0d0b7d0b0d0b4d182d0b0d0bad0bed0b5
       d182d0bed0b3d0b4d0b0d0bfd0bed187d182d0b8d09fd0bed181d0bbd0b5d182
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 74]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       d0b0d0bad0b8d0b5d0bdd0bed0b2d18bd0b9d181d182d0bed0b8d182d182d0b0
       d0bad0b8d185d181d180d0b0d0b7d183d0a1d0b0d0bdd0bad182d184d0bed180
       d183d0bcd09ad0bed0b3d0b4d0b0d0bad0bdd0b8d0b3d0b8d181d0bbd0bed0b2
@@ -4174,6 +4196,14 @@ Internet-Draft                   Brotli                       April 2015
       d8b3d8a7d984d8b4d98ad8aed985d986d8aad8afd98ad8a7d984d8b9d8b1d8a8
       d8a7d984d982d8b5d8b5d8a7d981d984d8a7d985d8b9d984d98ad987d8a7d8aa
       d8add8afd98ad8abd8a7d984d984d987d985d8a7d984d8b9d985d984d985d983
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 75]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       d8aad8a8d8a9d98ad985d983d986d983d8a7d984d8b7d981d984d981d98ad8af
       d98ad988d8a5d8afd8a7d8b1d8a9d8aad8a7d8b1d98ad8aed8a7d984d8b5d8ad
       d8a9d8aad8b3d8acd98ad984d8a7d984d988d982d8aad8b9d986d8afd985d8a7
@@ -4196,14 +4226,6 @@ Internet-Draft                   Brotli                       April 2015
       72207468616e74656d7065726174757265646576656c6f706d656e74636f6d70
       65746974696f6e706c616365686f6c6465727669736962696c6974793a636f70
       797269676874223e3022206865696768743d226576656e2074686f7567687265
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 75]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       706c6163656d656e7464657374696e6174696f6e436f72706f726174696f6e3c
       756c20636c6173733d224173736f63696174696f6e696e646976696475616c73
       706572737065637469766573657454696d656f75742875726c28687474703a2f
@@ -4230,6 +4252,14 @@ Internet-Draft                   Brotli                       April 2015
       62736572766174696f6e6d61696e74656e616e6365656e636f756e7465726564
       3c683220636c6173733d226d6f726520726563656e7469742068617320626565
       6e696e766173696f6e206f66292e67657454696d65282966756e64616d656e74
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 76]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       616c4465737069746520746865223e3c6469762069643d22696e737069726174
       696f6e6578616d696e6174696f6e7072657061726174696f6e6578706c616e61
       74696f6e3c696e7075742069643d223c2f613e3c2f7370616e3e76657273696f
@@ -4252,14 +4282,6 @@ Internet-Draft                   Brotli                       April 2015
       726f67726573736976656d696c6c696f6e73206f667374617465732074686174
       656e666f7263656d656e7461726f756e6420746865206f6e6520616e6f746865
       722e706172656e744e6f64656167726963756c74757265416c7465726e617469
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 76]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       76657265736561726368657273746f7761726473207468654d6f7374206f6620
       7468656d616e79206f746865722028657370656369616c6c793c746420776964
       74683d223b77696474683a31303025696e646570656e64656e743c683320636c
@@ -4286,6 +4308,14 @@ Internet-Draft                   Brotli                       April 2015
       656c79497420686173206265656e697420646f6573206e6f74636f6e74726172
       7920746f696e6861626974616e7473696d70726f76656d656e747363686f6c61
       7273686970636f6e73756d7074696f6e696e737472756374696f6e666f722065
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 77]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       78616d706c656f6e65206f72206d6f726570783b2070616464696e6774686520
       63757272656e746120736572696573206f6661726520757375616c6c79726f6c
       6520696e2074686570726576696f75736c792064657269766174697665736576
@@ -4308,14 +4338,6 @@ Internet-Draft                   Brotli                       April 2015
       20746f616d6f6e67206f74686572636f6d706172656420746f746f2073617920
       74686174456e67696e656572696e676120646966666572656e74726566657272
       656420746f646966666572656e63657362656c696566207468617470686f746f
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 77]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6772617068736964656e74696679696e67486973746f7279206f662052657075
       626c6963206f666e65636573736172696c7970726f626162696c697479746563
       686e6963616c6c796c656176696e672074686573706563746163756c61726672
@@ -4342,6 +4364,14 @@ Internet-Draft                   Brotli                       April 2015
       696e6365206f66776869636820776f756c646465737069746520746865736369
       656e7469666963206c656769736c61747572652e696e6e657248544d4c20616c
       6c65676174696f6e734167726963756c74757265776173207573656420696e61
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 78]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       7070726f61636820746f696e74656c6c6967656e747965617273206c61746572
       2c73616e732d736572696664657465726d696e696e67506572666f726d616e63
       65617070656172616e6365732c20776869636820697320666f756e646174696f
@@ -4364,14 +4394,6 @@ Internet-Draft                   Brotli                       April 2015
       2070656f706c6579656172732061667465727468657265206973206e6f746865
       20686967686573746672657175656e746c79207468657920646f206e6f746172
       67756564207468617473686f7765642074686174707265646f6d696e616e7474
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 78]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       68656f6c6f676963616c6279207468652074696d65636f6e7369646572696e67
       73686f72742d6c697665643c2f7370616e3e3c2f613e63616e20626520757365
       6476657279206c6974746c656f6e65206f66207468652068616420616c726561
@@ -4398,6 +4420,14 @@ Internet-Draft                   Brotli                       April 2015
       3c6c696e6b2072656c3d225468697320697320746865203c6120687265663d22
       2f706f70756c6172697a6564696e766f6c76656420696e617265207573656420
       746f616e64207365766572616c6d616465206279207468657365656d7320746f
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 79]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2062656c696b656c79207468617450616c657374696e69616e6e616d65642061
       66746572697420686164206265656e6d6f737420636f6d6d6f6e746f20726566
       657220746f6275742074686973206973636f6e736563757469766574656d706f
@@ -4420,14 +4450,6 @@ Internet-Draft                   Brotli                       April 2015
       42656361757365207468657468697320706572696f6422206e616d653d227122
       20636f6e66696e656420746f6120726573756c74206f6676616c75653d222220
       2f3e69732061637475616c6c79456e7669726f6e6d656e740d0a3c2f68656164
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 79]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       3e0d0a436f6e76657273656c792c3e0a3c6469762069643d2230222077696474
       683d223169732070726f6261626c7968617665206265636f6d65636f6e74726f
       6c6c696e677468652070726f626c656d636974697a656e73206f66706f6c6974
@@ -4454,6 +4476,14 @@ Internet-Draft                   Brotli                       April 2015
       73206f66646973636f7665726965736173736f63696174696f6e65646765206f
       6620746865737472656e677468206f66706f736974696f6e20696e7072657365
       6e742d646179756e6976657273616c6c79746f20666f726d2074686562757420
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 80]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       696e7374656164636f72706f726174696f6e617474616368656420746f697320
       636f6d6d6f6e6c79726561736f6e7320666f72202671756f743b746865206361
       6e206265206d6164657761732061626c6520746f7768696368206d65616e7362
@@ -4476,14 +4506,6 @@ Internet-Draft                   Brotli                       April 2015
       7469616c616e6420736f6d65206f666b696e67206f6620746865726561637469
       6f6e20746f317374204561726c206f6663756c7475726520616e647072696e63
       6970616c6c793c2f7469746c653e0a2020746865792063616e2062656261636b
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 80]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       20746f20746865736f6d65206f66206869736578706f7375726520746f617265
       2073696d696c6172666f726d206f66207468656164644661766f726974656369
       74697a656e736869707061727420696e2074686570656f706c65207769746869
@@ -4510,6 +4532,14 @@ Internet-Draft                   Brotli                       April 2015
       696f61637469766572656a6563746564206279776974686f757420616e796869
       73206661746865722c776869636820636f756c64636f7079206f662074686574
       6f20696e6469636174656120706f6c69746963616c6163636f756e7473206f66
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 81]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       636f6e7374697475746573776f726b6564207769746865723c2f613e3c2f6c69
       3e6f6620686973206c6966656163636f6d70616e696564636c69656e74576964
       746870726576656e74207468654c656769736c6174697665646966666572656e
@@ -4532,14 +4562,6 @@ Internet-Draft                   Brotli                       April 2015
       7420776964656c79776f756c64206c61746572616e6420706572686170737269
       736520746f207468656f6363757273207768656e756e64657220776869636863
       6f6e646974696f6e732e746865207765737465726e7468656f72792074686174
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 81]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       69732070726f64756365647468652063697479206f66696e2077686963682068
       657365656e20696e207468657468652063656e7472616c6275696c64696e6720
       6f666d616e79206f662068697361726561206f6620746865697320746865206f
@@ -4566,6 +4588,14 @@ Internet-Draft                   Brotli                       April 2015
       73616e642072656c6174656474686520726f6c65206f6670726f706f73656420
       62796f6620746865206265737465616368206f746865722e436f6e7374616e74
       696e6570656f706c652066726f6d6469616c65637473206f66746f2072657669
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 82]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       73696f6e7761732072656e616d65646120736f75726365206f6674686520696e
       697469616c6c61756e6368656420696e70726f7669646520746865746f207468
       6520776573747768657265207468657265616e642073696d696c617262657477
@@ -4588,14 +4618,6 @@ Internet-Draft                   Brotli                       April 2015
       7370726f7465636369c3b36e696d706f7274616e746573696d706f7274616e63
       6961706f736962696c69646164696e7465726573616e746563726563696d6965
       6e746f6e65636573696461646573737573637269626972736561736f63696163
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 82]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       69c3b36e646973706f6e69626c65736576616c75616369c3b36e657374756469
       616e746573726573706f6e7361626c657265736f6c756369c3b36e6775616461
       6c616a6172617265676973747261646f736f706f7274756e69646164636f6d65
@@ -4622,6 +4644,14 @@ Internet-Draft                   Brotli                       April 2015
       6469763e6e6f74696669636174696f6e27756e646566696e6564272946757274
       6865726d6f72652c62656c696576652074686174696e6e657248544d4c203d20
       7072696f7220746f207468656472616d61746963616c6c79726566657272696e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 83]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6720746f6e65676f74696174696f6e73686561647175617274657273536f7574
       6820416672696361756e7375636365737366756c50656e6e73796c76616e6961
       4173206120726573756c742c3c68746d6c206c616e673d22266c743b2f737570
@@ -4644,14 +4674,6 @@ Internet-Draft                   Brotli                       April 2015
       6f6e7765616c746872616e67696e672066726f6d696e20776869636820746865
       6174206c65617374206f6e65726570726f64756374696f6e656e6379636c6f70
       656469613b666f6e742d73697a653a316a7572697364696374696f6e61742074
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 83]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6861742074696d65223e3c6120636c6173733d22496e206164646974696f6e2c
       6465736372697074696f6e2b636f6e766572736174696f6e636f6e7461637420
       7769746869732067656e6572616c6c79722220636f6e74656e743d2272657072
@@ -4678,6 +4700,14 @@ Internet-Draft                   Brotli                       April 2015
       743d22316d6f64696669636174696f6e496e646570656e64656e636564697669
       64656420696e746f67726561746572207468616e616368696576656d656e7473
       65737461626c697368696e674a61766153637269707422206e65766572746865
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 84]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6c6573737369676e69666963616e636542726f616463617374696e673e266e62
       73703b3c2f74643e636f6e7461696e6572223e0a737563682061732074686520
       696e666c75656e6365206f666120706172746963756c61727372633d27687474
@@ -4700,14 +4730,6 @@ Internet-Draft                   Brotli                       April 2015
       6120687265663d22636c6f736520746f207468656578616d706c6573206f6620
       69732061626f757420746865287365652062656c6f77292e222069643d227365
       6172636870726f66657373696f6e616c697320617661696c61626c6574686520
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 84]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6f6666696369616c09093c2f7363726970743e0a0a09093c6469762069643d22
       616363656c65726174696f6e7468726f756768207468652048616c6c206f6620
       46616d656465736372697074696f6e737472616e736c6174696f6e73696e7465
@@ -4734,6 +4756,14 @@ Internet-Draft                   Brotli                       April 2015
       6c69747970726f706f7274696f6e616c6f757473696465207468652061737472
       6f6e6f6d6963616c68756d616e206265696e67736e616d65206f662074686520
       61726520666f756e6420696e617265206261736564206f6e736d616c6c657220
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 85]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       7468616e6120706572736f6e2077686f657870616e73696f6e206f6661726775
       696e6720746861746e6f77206b6e6f776e206173496e20746865206561726c79
       696e7465726d656469617465646572697665642066726f6d5363616e64696e61
@@ -4756,14 +4786,6 @@ Internet-Draft                   Brotli                       April 2015
       20617265206e6f7472656a65637465642074686563726974696369736d206f66
       647572696e6720776869636870726f6261626c79207468657468697320617274
       69636c652866756e6374696f6e28297b49742073686f756c64206265616e2061
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 85]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       677265656d656e746163636964656e74616c6c79646966666572732066726f6d
       417263686974656374757265626574746572206b6e6f776e617272616e67656d
       656e7473696e666c75656e6365206f6e617474656e646564207468656964656e
@@ -4790,6 +4812,14 @@ Internet-Draft                   Brotli                       April 2015
       642062796120776964652072616e67656f6e20626568616c66206f6676616c69
       676e3d22746f70227072696e6369706c65206f666174207468652074696d652c
       3c2f6e6f7363726970743e0d7361696420746f2068617665696e207468652066
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 86]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       697273747768696c65206f74686572736879706f746865746963616c7068696c
       6f736f7068657273706f776572206f6620746865636f6e7461696e656420696e
       706572666f726d6564206279696e6162696c69747920746f7765726520777269
@@ -4812,14 +4842,6 @@ Internet-Draft                   Brotli                       April 2015
       6666696369656e74676976656e2062792074686573746174696e672074686174
       657870656e646974757265733c2f7370616e3e3c2f613e0a74686f7567687420
       746861746f6e2074686520626173697363656c6c70616464696e673d696d6167
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 86]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       65206f662074686572657475726e696e6720746f696e666f726d6174696f6e2c
       736570617261746564206279617373617373696e61746564732220636f6e7465
       6e743d22617574686f72697479206f666e6f7274687765737465726e3c2f6469
@@ -4846,6 +4868,14 @@ Internet-Draft                   Brotli                       April 2015
       73733d226566666563746976656c792065766f6c76656420696e746f7365656d
       20746f2068617665776869636820697320746865746865726520776173206e6f
       616e20657863656c6c656e74616c6c206f662074686573656465736372696265
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 87]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       64206279496e2070726163746963652c62726f616463617374696e6763686172
       67656420776974687265666c656374656420696e7375626a656374656420746f
       6d696c697461727920616e64746f2074686520706f696e7465636f6e6f6d6963
@@ -4868,14 +4898,6 @@ Internet-Draft                   Brotli                       April 2015
       706f737369626c797374616e64617264697a6564726573706f6e736554657874
       77617320696e74656e646564726563656976656420746865617373756d656420
       746861746172656173206f66207468657072696d6172696c7920696e74686520
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 87]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6261736973206f66696e207468652073656e73656163636f756e747320666f72
       64657374726f7965642062796174206c656173742074776f776173206465636c
       61726564636f756c64206e6f74206265536563726574617279206f6661707065
@@ -4902,6 +4924,14 @@ Internet-Draft                   Brotli                       April 2015
       6f6e6573646573636f6e65637461646f696e7374616c616369c3b36e7265616c
       697a616369c3b36e7574696c697a616369c3b36e656e6369636c6f7065646961
       656e6665726d656461646573696e737472756d656e746f73657870657269656e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 88]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       63696173696e73746974756369c3b36e706172746963756c6172657373756263
       617465676f726961d182d0bed0bbd18cd0bad0bed0a0d0bed181d181d0b8d0b8
       d180d0b0d0b1d0bed182d18bd0b1d0bed0bbd18cd188d0b5d0bfd180d0bed181
@@ -4924,14 +4954,6 @@ Internet-Draft                   Brotli                       April 2015
       d0bbd0b0d182d18cd0b4d0b5d0bdd18cd0b3d0b8d0bfd0b5d180d0b8d0bed0b4
       d0b1d0b8d0b7d0bdd0b5d181d0bed181d0bdd0bed0b2d0b5d0bcd0bed0bcd0b5
       d0bdd182d0bad183d0bfd0b8d182d18cd0b4d0bed0bbd0b6d0bdd0b0d180d0b0
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 88]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       d0bcd0bad0b0d185d0bdd0b0d187d0b0d0bbd0bed0a0d0b0d0b1d0bed182d0b0
       d0a2d0bed0bbd18cd0bad0bed181d0bed0b2d181d0b5d0bcd0b2d182d0bed180
       d0bed0b9d0bdd0b0d187d0b0d0bbd0b0d181d0bfd0b8d181d0bed0bad181d0bb
@@ -4958,6 +4980,14 @@ Internet-Draft                   Brotli                       April 2015
       b5e0a4bee0a495e0a4b0e0a4a4e0a587e0a4aee0a587e0a4b0e0a587e0a4b9e0
       a58be0a4a8e0a587e0a4b8e0a495e0a4a4e0a587e0a4ace0a4b9e0a581e0a4a4
       e0a4b8e0a4bee0a487e0a49fe0a4b9e0a58be0a497e0a4bee0a49ce0a4bee0a4
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 89]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       a8e0a587e0a4aee0a4bfe0a4a8e0a49fe0a495e0a4b0e0a4a4e0a4bee0a495e0
       a4b0e0a4a8e0a4bee0a489e0a4a8e0a495e0a587e0a4afe0a4b9e0a4bee0a481
       e0a4b8e0a4ace0a4b8e0a587e0a4ade0a4bee0a4b7e0a4bee0a486e0a4aae0a4
@@ -4980,14 +5010,6 @@ Internet-Draft                   Brotli                       April 2015
       a4b8e0a482e0a4a6e0a4b8e0a4b5e0a4bee0a4b2e0a4b9e0a58be0a4a8e0a4be
       e0a4b9e0a58be0a4a4e0a580e0a49ce0a588e0a4b8e0a587e0a4b5e0a4bee0a4
       aae0a4b8e0a49ce0a4a8e0a4a4e0a4bee0a4a8e0a587e0a4a4e0a4bee0a49ce0
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 89]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       a4bee0a4b0e0a580e0a498e0a4bee0a4afe0a4b2e0a49ce0a4bfe0a4b2e0a587
       e0a4a8e0a580e0a49ae0a587e0a49ce0a4bee0a482e0a49ae0a4aae0a4a4e0a5
       8de0a4b0e0a497e0a582e0a497e0a4b2e0a49ce0a4bee0a4a4e0a587e0a4ace0
@@ -5014,6 +5036,14 @@ Internet-Draft                   Brotli                       April 2015
       95e0a4bee0a49ce0a4b5e0a4bee0a4ace0a4aae0a582e0a4b0e0a4bee0a4ace0
       a4a1e0a4bce0a4bee0a4b8e0a58ce0a4a6e0a4bee0a4b6e0a587e0a4afe0a4b0
       e0a495e0a4bfe0a4afe0a587e0a495e0a4b9e0a4bee0a482e0a485e0a495e0a4
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 90]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       b8e0a4b0e0a4ace0a4a8e0a4bee0a48fe0a4b5e0a4b9e0a4bee0a482e0a4b8e0
       a58de0a4a5e0a4b2e0a4aee0a4bfe0a4b2e0a587e0a4b2e0a587e0a496e0a495
       e0a4b5e0a4bfe0a4b7e0a4afe0a495e0a58de0a4b0e0a482e0a4b8e0a4aee0a5
@@ -5036,14 +5066,6 @@ Internet-Draft                   Brotli                       April 2015
       d988d982d98ad8aad8a7d984d8a3d988d984d989d8a7d984d8a8d8b1d98ad8af
       d8a7d984d983d984d8a7d985d8a7d984d8b1d8a7d8a8d8b7d8a7d984d8b4d8ae
       d8b5d98ad8b3d98ad8a7d8b1d8a7d8aad8a7d984d8abd8a7d984d8abd8a7d984
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 90]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       d8b5d984d8a7d8a9d8a7d984d8add8afd98ad8abd8a7d984d8b2d988d8a7d8b1
       d8a7d984d8aed984d98ad8acd8a7d984d8acd985d98ad8b9d8a7d984d8b9d8a7
       d985d987d8a7d984d8acd985d8a7d984d8a7d984d8b3d8a7d8b9d8a9d985d8b4
@@ -5070,6 +5092,14 @@ Internet-Draft                   Brotli                       April 2015
       696f6e616c6c79204164646974696f6e616c6c792c4e6f72746820416d657269
       636170783b6261636b67726f756e646f70706f7274756e6974696573456e7465
       727461696e6d656e742e746f4c6f77657243617365286d616e75666163747572
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 91]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       696e6770726f66657373696f6e616c20636f6d62696e65642077697468466f72
       20696e7374616e63652c636f6e73697374696e67206f6622206d61786c656e67
       74683d2272657475726e2066616c73653b636f6e7363696f75736e6573734d65
@@ -5092,14 +5122,6 @@ Internet-Draft                   Brotli                       April 2015
       7372633d222f2866756e6374696f6e2829207b61726520617661696c61626c65
       0a093c6c696e6b2072656c3d22207372633d27687474703a2f2f696e74657265
       7374656420696e636f6e76656e74696f6e616c202220616c743d2222202f3e3c
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 91]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       2f6172652067656e6572616c6c7968617320616c736f206265656e6d6f737420
       706f70756c617220636f72726573706f6e64696e676372656469746564207769
       746874796c653d22626f726465723a3c2f613e3c2f7370616e3e3c2f2e676966
@@ -5126,6 +5148,14 @@ Internet-Draft                   Brotli                       April 2015
       6e6365206f6664656e6f6d696e6174696f6e736261636b67726f756e643a2023
       6c656e677468206f662074686564657465726d696e6174696f6e61207369676e
       69666963616e742220626f726465723d2230223e7265766f6c7574696f6e6172
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 92]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       797072696e6369706c6573206f66697320636f6e736964657265647761732064
       6576656c6f706564496e646f2d4575726f7065616e76756c6e657261626c6520
       746f70726f706f6e656e7473206f6661726520736f6d6574696d6573636c6f73
@@ -5148,14 +5178,6 @@ Internet-Draft                   Brotli                       April 2015
       756f743b7365766572616c2074696d6573726570726573656e7420746865626f
       64793e0a3c2f68746d6c3e74686f7567687420746f206265706f70756c617469
       6f6e206f66706f73736962696c697469657370657263656e74616765206f6661
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 92]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       636365737320746f20746865616e20617474656d707420746f70726f64756374
       696f6e206f666a71756572792f6a717565727974776f20646966666572656e74
       62656c6f6e6720746f2074686565737461626c6973686d656e747265706c6163
@@ -5182,6 +5204,14 @@ Internet-Draft                   Brotli                       April 2015
       746c792c496e7465726e6174696f6e616c616c74686f75676820736f6d657468
       617420776f756c64206265776f726c642773206669727374636c617373696669
       6564206173626f74746f6d206f662074686528706172746963756c61726c7961
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 93]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6c69676e3d226c65667422206d6f737420636f6d6d6f6e6c7962617369732066
       6f7220746865666f756e646174696f6e206f66636f6e747269627574696f6e73
       706f70756c6172697479206f6663656e746572206f6620746865746f20726564
@@ -5204,14 +5234,6 @@ Internet-Draft                   Brotli                       April 2015
       6172476f7665726e6d656e74206f6667656e65726174696f6e206f6668617665
       206e6f74206265656e7365766572616c207965617273636f6d6d69746d656e74
       20746f09093c756c20636c6173733d2276697375616c697a6174696f6e313974
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 93]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       682063656e747572792c70726163746974696f6e657273746861742068652077
       6f756c64616e6420636f6e74696e7565646f636375706174696f6e206f666973
       20646566696e656420617363656e747265206f662074686574686520616d6f75
@@ -5238,6 +5260,14 @@ Internet-Draft                   Brotli                       April 2015
       656469732072656c6174656420746f626563616d65206f6e65206f6669732066
       72657175656e746c796c6976696e6720696e207468657468656f726574696361
       6c6c79466f6c6c6f77696e67207468655265766f6c7574696f6e617279676f76
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 94]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       65726e6d656e7420696e69732064657465726d696e656474686520706f6c6974
       6963616c696e74726f647563656420696e73756666696369656e7420746f6465
       736372697074696f6e223e73686f72742073746f726965737365706172617469
@@ -5260,14 +5290,6 @@ Internet-Draft                   Brotli                       April 2015
       626520636f6e73696465726564636861726163746572697a6564636c65617249
       6e74657276616c617574686f726974617469766546656465726174696f6e206f
       6677617320737563636565646564616e64207468657265206172656120636f6e
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 94]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       73657175656e636574686520507265736964656e74616c736f20696e636c7564
       65646672656520736f66747761726573756363657373696f6e206f6664657665
       6c6f706564207468657761732064657374726f796564617761792066726f6d20
@@ -5294,6 +5316,14 @@ Internet-Draft                   Brotli                       April 2015
       223e3c64697620636c6173733d22646973616d626967756174696f6e446f6d61
       696e4e616d65272c202761646d696e697374726174696f6e73696d756c74616e
       656f75736c797472616e73706f72746174696f6e496e7465726e6174696f6e61
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 95]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6c206d617267696e2d626f74746f6d3a726573706f6e736962696c6974793c21
       5b656e6469665d2d2d3e0a3c2f3e3c6d657461206e616d653d22696d706c656d
       656e746174696f6e696e667261737472756374757265726570726573656e7461
@@ -5316,14 +5346,6 @@ Internet-Draft                   Brotli                       April 2015
       696e67202671756f743b2d2d3c215b656e6469665d2d2d3e5072696d65204d69
       6e697374657263686172616374657269737469633c2f613e203c6120636c6173
       733d74686520686973746f7279206f66206f6e6d6f7573656f7665723d227468
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 95]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6520676f7665726e6d656e74687265663d2268747470733a2f2f776173206f72
       6967696e616c6c7977617320696e74726f6475636564636c6173736966696361
       74696f6e726570726573656e74617469766561726520636f6e73696465726564
@@ -5350,6 +5372,14 @@ Internet-Draft                   Brotli                       April 2015
       207468656170706c69636174696f6e206f663c7370616e20636c6173733d2273
       62656c696576656420746f206265656d656e742827736372697074273c2f613e
       0a3c2f6c693e0a3c6c697665727920646966666572656e743e3c7370616e2063
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 96]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6c6173733d226f7074696f6e2076616c75653d2228616c736f206b6e6f776e20
       6173093c6c693e3c6120687265663d223e3c696e707574206e616d653d227365
       706172617465642066726f6d726566657272656420746f2061732076616c6967
@@ -5372,14 +5402,6 @@ Internet-Draft                   Brotli                       April 2015
       6d656d626572206f66207468652070616464696e672d72696768743a7472616e
       736c6174696f6e206f66696e746572707265746174696f6e20687265663d2768
       7474703a2f2f77686574686572206f72206e6f7454686572652061726520616c
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 96]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       736f746865726520617265206d616e796120736d616c6c206e756d6265726f74
       686572207061727473206f66696d706f737369626c6520746f2020636c617373
       3d22627574746f6e6c6f636174656420696e207468652e20486f77657665722c
@@ -5406,6 +5428,14 @@ Internet-Draft                   Brotli                       April 2015
       7465642077697468616e64206d616e79206f74686572616c74686f7567682069
       74206973626567696e6e696e672077697468203c7370616e20636c6173733d22
       64657363656e64616e7473206f663c7370616e20636c6173733d226920616c69
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 97]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       676e3d227269676874223c2f686561643e0a3c626f6479206173706563747320
       6f66207468656861732073696e6365206265656e4575726f7065616e20556e69
       6f6e72656d696e697363656e74206f666d6f726520646966666963756c745669
@@ -5428,14 +5458,6 @@ Internet-Draft                   Brotli                       April 2015
       7573656461707065617220746f206861766573756363657373206f6620746865
       696e74656e64656420746f20626570726573656e7420696e207468657374796c
       653d22636c6561723a620d0a3c2f7363726970743e0d0a3c77617320666f756e
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 97]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       64656420696e696e7465727669657720776974685f69642220636f6e74656e74
       3d226361706974616c206f66207468650d0a3c6c696e6b2072656c3d22737265
       6c65617365206f6620746865706f696e74206f75742074686174784d4c487474
@@ -5462,6 +5484,14 @@ Internet-Draft                   Brotli                       April 2015
       7370616e20636c6173733d22746865207375626a656374206f66646566696e69
       74696f6e73206f663e0d0a3c6c696e6b2072656c3d22636c61696d2074686174
       207468656861766520646576656c6f7065643c7461626c652077696474683d22
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 98]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       63656c6562726174696f6e206f66466f6c6c6f77696e672074686520746f2064
       697374696e67756973683c7370616e20636c6173733d226274616b657320706c
       61636520696e756e64657220746865206e616d656e6f74656420746861742074
@@ -5484,14 +5514,6 @@ Internet-Draft                   Brotli                       April 2015
       6966666572656e74617265206f6674656e2075736564746f20656e7375726520
       7468617461677265656d656e742077697468636f6e7461696e696e6720746865
       617265206672657175656e746c79696e666f726d6174696f6e206f6e6578616d
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 98]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       706c6520697320746865726573756c74696e6720696e20613c2f613e3c2f6c69
       3e3c2f756c3e20636c6173733d22666f6f746572616e6420657370656369616c
       6c79747970653d22627574746f6e22203c2f7370616e3e3c2f7370616e3e7768
@@ -5518,6 +5540,14 @@ Internet-Draft                   Brotli                       April 2015
       d0b8d0bad0bed182d0bed180d18bd0b9d187d0b5d0bbd0bed0b2d0b5d0bad181
       d0b8d181d182d0b5d0bcd18bd09dd0bed0b2d0bed181d182d0b8d0bad0bed182
       d0bed180d18bd185d0bed0b1d0bbd0b0d181d182d18cd0b2d180d0b5d0bcd0b5
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015               [Page 99]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       d0bdd0b8d0bad0bed182d0bed180d0b0d18fd181d0b5d0b3d0bed0b4d0bdd18f
       d181d0bad0b0d187d0b0d182d18cd0bdd0bed0b2d0bed181d182d0b8d0a3d0ba
       d180d0b0d0b8d0bdd18bd0b2d0bed0bfd180d0bed181d18bd0bad0bed182d0be
@@ -5540,14 +5570,6 @@ Internet-Draft                   Brotli                       April 2015
       d984d8a3d982d8b3d8a7d985d8a7d984d8b6d8bad8b7d8a7d8aad8a7d984d981
       d98ad8afd98ad988d8a7d984d8aad8b1d8add98ad8a8d8a7d984d8acd8afd98a
       d8afd8a9d8a7d984d8aad8b9d984d98ad985d8a7d984d8a3d8aed8a8d8a7d8b1
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015               [Page 99]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       d8a7d984d8a7d981d984d8a7d985d8a7d984d8a3d981d984d8a7d985d8a7d984
       d8aad8a7d8b1d98ad8aed8a7d984d8aad982d986d98ad8a9d8a7d984d8a7d984
       d8b9d8a7d8a8d8a7d984d8aed988d8a7d8b7d8b1d8a7d984d985d8acd8aad985
@@ -5574,6 +5596,14 @@ Internet-Draft                   Brotli                       April 2015
       6f726d20616374696f6e3d222f7d626f64797b6d617267696e3a303b456e6379
       636c6f7065646961206f6676657273696f6e206f6620746865202e6372656174
       65456c656d656e74286e616d652220636f6e74656e743d223c2f6469763e0a3c
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 100]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2f6469763e0a0a61646d696e697374726174697665203c2f626f64793e0a3c2f
       68746d6c3e686973746f7279206f662074686520223e3c696e70757420747970
       653d22706f7274696f6e206f66207468652061732070617274206f6620746865
@@ -5596,14 +5626,6 @@ Internet-Draft                   Brotli                       April 2015
       6173206f6e65206f662074686520756e74696c206869732064656174687d2928
       293b0a3c2f7363726970743e6f74686572206c616e677561676573636f6d7061
       72656420746f20746865706f7274696f6e73206f6620746865746865204e6574
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 100]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       6865726c616e6473746865206d6f737420636f6d6d6f6e6261636b67726f756e
       643a75726c286172677565642074686174207468657363726f6c6c696e673d22
       6e6f2220696e636c7564656420696e207468654e6f72746820416d6572696361
@@ -5630,6 +5652,14 @@ Internet-Draft                   Brotli                       April 2015
       206f662074686573746f7050726f7061676174696f6e696e7465726573742069
       6e20746865617661696c6162696c697479206f666170706561727320746f2068
       617665656c656374726f6d61676e65746963656e61626c655365727669636573
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 101]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2866756e6374696f6e206f6620746865497420697320696d706f7274616e743c
       2f7363726970743e3c2f6469763e66756e6374696f6e28297b7661722072656c
       617469766520746f207468656173206120726573756c74206f66207468652070
@@ -5652,14 +5682,6 @@ Internet-Draft                   Brotli                       April 2015
       a4bee0a4a8e0a587e0a495e0a581e0a4aee0a4bee0a4b0e0a4ace0a58de0a4b2
       e0a589e0a497e0a4aee0a4bee0a4b2e0a4bfe0a495e0a4aee0a4b9e0a4bfe0a4
       b2e0a4bee0a4aae0a583e0a4b7e0a58de0a4a0e0a4ace0a4a2e0a4bce0a4a4e0
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 101]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       a587e0a4ade0a4bee0a49ce0a4aae0a4bee0a495e0a58de0a4b2e0a4bfe0a495
       e0a49fe0a58de0a4b0e0a587e0a4a8e0a496e0a4bfe0a4b2e0a4bee0a4abe0a4
       a6e0a58ce0a4b0e0a4bee0a4a8e0a4aee0a4bee0a4aee0a4b2e0a587e0a4aee0
@@ -5686,6 +5708,14 @@ Internet-Draft                   Brotli                       April 2015
       87e0a4b8e0a58de0a4a5e0a4bee0a4a8e0a495e0a4b0e0a58be0a4a1e0a4bce0
       a4aee0a581e0a495e0a58de0a4a4e0a4afe0a58be0a49ce0a4a8e0a4bee0a495
       e0a583e0a4aae0a4afe0a4bee0a4aae0a58be0a4b8e0a58de0a49fe0a498e0a4
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 102]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       b0e0a587e0a4b2e0a582e0a495e0a4bee0a4b0e0a58de0a4afe0a4b5e0a4bfe0
       a49ae0a4bee0a4b0e0a4b8e0a582e0a49ae0a4a8e0a4bee0a4aee0a582e0a4b2
       e0a58de0a4afe0a4a6e0a587e0a496e0a587e0a482e0a4b9e0a4aee0a587e0a4
@@ -5708,14 +5738,6 @@ Internet-Draft                   Brotli                       April 2015
       732e6a73223e3c2f7363726970743e0a2f66617669636f6e2e69636f22202f3e
       6f7065726174696e672073797374656d22207374796c653d2277696474683a31
       7461726765743d225f626c616e6b223e537461746520556e6976657273697479
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 102]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       746578742d616c69676e3a6c6566743b0a646f63756d656e742e777269746528
       2c20696e636c7564696e67207468652061726f756e642074686520776f726c64
       293b0d0a3c2f7363726970743e0d0a3c22207374796c653d226865696768743a
@@ -5742,6 +5764,14 @@ Internet-Draft                   Brotli                       April 2015
       2e6a73223e3c2f7363726970743e0d0a6c696e6b2072656c3d2269636f6e2220
       2720616c743d272720636c6173733d27666f726d6174696f6e206f6620746865
       76657273696f6e73206f6620746865203c2f613e3c2f6469763e3c2f6469763e
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 103]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2f706167653e0a20203c706167653e0a3c64697620636c6173733d22636f6e74
       626563616d652074686520666972737462616861736120496e646f6e65736961
       656e676c697368202873696d706c6529ce95cebbcebbceb7cebdceb9cebaceac
@@ -5764,14 +5794,6 @@ Internet-Draft                   Brotli                       April 2015
       d8a7d984d8aad8b5d8a7d985d98ad985d8a7d984d8a5d8b3d984d8a7d985d98a
       d8a7d984d985d8b4d8a7d8b1d983d8a9d8a7d984d985d8b1d8a6d98ad8a7d8aa
       726f626f74732220636f6e74656e743d223c6469762069643d22666f6f746572
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 103]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       223e74686520556e69746564205374617465733c696d67207372633d22687474
       703a2f2f2e6a70677c72696768747c7468756d627c2e6a73223e3c2f73637269
       70743e0d0a3c6c6f636174696f6e2e70726f746f636f6c6672616d65626f7264
@@ -5798,6 +5820,14 @@ Internet-Draft                   Brotli                       April 2015
       656c3d226e6f666f6c6c6f77223e207461726765743d225f626c616e6b223e63
       6c61696d696e6720746861742074686568747470253341253246253246777777
       2e6d616e69666573746174696f6e73206f665072696d65204d696e6973746572
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 104]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       206f66696e666c75656e63656420627920746865636c6173733d22636c656172
       666978223e2f6469763e0d0a3c2f6469763e0d0a0d0a74687265652d64696d65
       6e73696f6e616c436875726368206f6620456e676c616e646f66204e6f727468
@@ -5820,14 +5850,6 @@ Internet-Draft                   Brotli                       April 2015
       2f68746d6c3e0dce95cebbcebbceb7cebdceb9cebaceac0a74616b6520616476
       616e74616765206f66616e642c206163636f7264696e6720746f617474726962
       7574656420746f207468654d6963726f736f66742057696e646f777374686520
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 104]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       66697273742063656e74757279756e6465722074686520636f6e74726f6c6469
       7620636c6173733d2268656164657273686f72746c7920616674657220746865
       6e6f7461626c6520657863657074696f6e74656e73206f662074686f7573616e
@@ -5854,6 +5876,14 @@ Internet-Draft                   Brotli                       April 2015
       67756167652220636f6e74656e743d223c6d65746120687474702d6571756976
       3d225072697661637920506f6c6963793c2f613e652822253343736372697074
       207372633d2722207461726765743d225f626c616e6b223e4f6e20746865206f
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 105]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       746865722068616e642c2e6a70677c7468756d627c72696768747c323c2f6469
       763e3c64697620636c6173733d223c646976207374796c653d22666c6f61743a
       6e696e657465656e74682063656e747572793c2f626f64793e0d0a3c2f68746d
@@ -5876,14 +5906,6 @@ Internet-Draft                   Brotli                       April 2015
       3d22746578742f63737322202f3e697420697320706f737369626c6520746f20
       4861727661726420556e697665727369747974796c6573686565742220687265
       663d222f746865206d61696e206368617261637465724f78666f726420556e69
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 105]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       7665727369747920206e616d653d226b6579776f7264732220637374796c653d
       22746578742d616c69676e3a74686520556e69746564204b696e67646f6d6665
       646572616c20676f7665726e6d656e743c646976207374796c653d226d617267
@@ -5910,6 +5932,14 @@ Internet-Draft                   Brotli                       April 2015
       64756374696f6e20746f636f6e73657175656e6365206f662074686564657061
       72747572652066726f6d20746865436f6e666564657261746520537461746573
       696e646967656e6f75732070656f706c657350726f63656564696e6773206f66
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 106]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       20746865696e666f726d6174696f6e206f6e207468657468656f726965732068
       617665206265656e696e766f6c76656d656e7420696e20746865646976696465
       6420696e746f20746872656561646a6163656e7420636f756e74726965736973
@@ -5932,14 +5962,6 @@ Internet-Draft                   Brotli                       April 2015
       75627374616e636574686f7573616e6473206f662079656172737472616e736c
       6174696f6e206f66207468653c2f6469763e0d0a3c2f6469763e0d0a0d0a3c61
       20687265663d22696e6465782e7068707761732065737461626c697368656420
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 106]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       696e6d696e2e6a73223e3c2f7363726970743e0a706172746963697061746520
       696e2074686561207374726f6e6720696e666c75656e63657374796c653d226d
       617267696e2d746f703a726570726573656e7465642062792074686567726164
@@ -5966,6 +5988,14 @@ Internet-Draft                   Brotli                       April 2015
       d0b8d0b8d090d0bbd0b5d0bad181d0b0d0bdd0b4d180e0a4a6e0a58de0a4b5e0
       a4bee0a4b0e0a4bee0a4aee0a588e0a4a8e0a581e0a485e0a4b2e0a4aae0a58d
       e0a4b0e0a4a6e0a4bee0a4a8e0a4ade0a4bee0a4b0e0a4a4e0a580e0a4afe0a4
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 107]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       85e0a4a8e0a581e0a4a6e0a587e0a4b6e0a4b9e0a4bfe0a4a8e0a58de0a4a6e0
       a580e0a487e0a482e0a4a1e0a4bfe0a4afe0a4bee0a4a6e0a4bfe0a4b2e0a58d
       e0a4b2e0a580e0a485e0a4a7e0a4bfe0a495e0a4bee0a4b0e0a4b5e0a580e0a4
@@ -5988,14 +6018,6 @@ Internet-Draft                   Brotli                       April 2015
       a4b9e0a4aae0a4b0e0a4bfe0a4a3e0a4bee0a4aee0a4ace0a58de0a4b0e0a4be
       e0a482e0a4a1e0a4ace0a49ae0a58de0a49ae0a58be0a482e0a489e0a4aae0a4
       b2e0a4ace0a58de0a4a7e0a4aee0a482e0a4a4e0a58de0a4b0e0a580e0a4b8e0
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 107]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       a482e0a4aae0a4b0e0a58de0a495e0a489e0a4aee0a58de0a4aee0a580e0a4a6
       e0a4aee0a4bee0a4a7e0a58de0a4afe0a4aee0a4b8e0a4b9e0a4bee0a4afe0a4
       a4e0a4bee0a4b6e0a4ace0a58de0a4a6e0a58be0a482e0a4aee0a580e0a4a1e0
@@ -6022,6 +6044,14 @@ Internet-Draft                   Brotli                       April 2015
       6f66662220746578742d616c69676e3a2063656e7465723b746f206c61737420
       76657273696f6e206279206261636b67726f756e642d636f6c6f723a20232220
       687265663d22687474703a2f2f7777772e2f6469763e3c2f6469763e3c646976
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 108]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       2069643d3c6120687265663d22232220636c6173733d22223e3c696d67207372
       633d22687474703a2f2f637269707422207372633d22687474703a2f2f0a3c73
       6372697074206c616e67756167653d222f2f454e222022687474703a2f2f7777
@@ -6044,14 +6074,6 @@ Internet-Draft                   Brotli                       April 2015
       6f2062657461626c652077696474683d22313030252220496e20616464697469
       6f6e20746f2074686520636f6e747269627574656420746f2074686520646966
       666572656e636573206265747765656e646576656c6f706d656e74206f662074
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 108]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       686520497420697320696d706f7274616e7420746f203c2f7363726970743e0a
       0a3c73637269707420207374796c653d22666f6e742d73697a653a313e3c2f73
       70616e3e3c7370616e2069643d67624c696272617279206f6620436f6e677265
@@ -6078,6 +6100,14 @@ Internet-Draft                   Brotli                       April 2015
       20696e636c756465757375616c6c7920726566657272656420746f696e646963
       6174696e67207468617420746865686176652073756767657374656420746861
       74616666696c6961746564207769746820746865636f7272656c6174696f6e20
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 109]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6265747765656e6e756d626572206f6620646966666572656e743e3c2f74643e
       3c2f74723e3c2f7461626c653e52657075626c6963206f66204972656c616e64
       0a3c2f7363726970743e0a3c73637269707420756e6465722074686520696e66
@@ -6100,14 +6130,6 @@ Internet-Draft                   Brotli                       April 2015
       6e673d2230222074686f7573616e6473206f662070656f706c65726564697265
       63747320686572652e20466f7268617665206368696c6472656e20756e646572
       2533452533432f7363726970742533452229293b3c6120687265663d22687474
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 109]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       703a2f2f7777772e3c6c693e3c6120687265663d22687474703a2f2f73697465
       5f6e616d652220636f6e74656e743d22746578742d6465636f726174696f6e3a
       6e6f6e657374796c653d22646973706c61793a206e6f6e653c6d657461206874
@@ -6134,6 +6156,14 @@ Internet-Draft                   Brotli                       April 2015
       687474702d65717569763d2263737322206d656469613d2273637265656e2220
       726573706f6e7369626c6520666f7220746865202220747970653d226170706c
       69636174696f6e2f22207374796c653d226261636b67726f756e642d68746d6c
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 110]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       3b20636861727365743d7574662d382220616c6c6f777472616e73706172656e
       63793d227374796c6573686565742220747970653d2274650d0a3c6d65746120
       687474702d65717569763d223e3c2f7370616e3e3c7370616e20636c6173733d
@@ -6156,14 +6186,6 @@ Internet-Draft                   Brotli                       April 2015
       3d227574662d3822203c696e70757420747970653d227465787422206578616d
       706c657320696e636c75646520746865223e3c696d67207372633d2268747470
       3a2f2f6970617274696369706174696f6e20696e207468657468652065737461
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 110]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       626c6973686d656e74206f660a3c2f6469763e0a3c64697620636c6173733d22
       26616d703b6e6273703b26616d703b6e6273703b746f2064657465726d696e65
       2077686574686572717569746520646966666572656e742066726f6d6d61726b
@@ -6190,6 +6212,14 @@ Internet-Draft                   Brotli                       April 2015
       d184d0bed180d0bcd0b0d186d0b8d0b8d183d0bfd180d0b0d0b2d0bbd0b5d0bd
       d0b8d18fd0bdd0b5d0bed0b1d185d0bed0b4d0b8d0bcd0bed0b8d0bdd184d0be
       d180d0bcd0b0d186d0b8d18fd098d0bdd184d0bed180d0bcd0b0d186d0b8d18f
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 111]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       d0a0d0b5d181d0bfd183d0b1d0bbd0b8d0bad0b8d0bad0bed0bbd0b8d187d0b5
       d181d182d0b2d0bed0b8d0bdd184d0bed180d0bcd0b0d186d0b8d18ed182d0b5
       d180d180d0b8d182d0bed180d0b8d0b8d0b4d0bed181d182d0b0d182d0bed187
@@ -6212,14 +6242,6 @@ Internet-Draft                   Brotli                       April 2015
       636f726174696f6e3a756e64657274686520626567696e6e696e67206f662074
       6865203c2f6469763e0a3c2f6469763e0a3c2f6469763e0a65737461626c6973
       686d656e74206f6620746865203c2f6469763e3c2f6469763e3c2f6469763e3c
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 111]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       2f642376696577706f72747b6d696e2d6865696768743a0a3c73637269707420
       7372633d22687474703a2f2f6f7074696f6e3e3c6f7074696f6e2076616c7565
       3d6f6674656e20726566657272656420746f206173202f6f7074696f6e3e0a3c
@@ -6246,6 +6268,14 @@ Internet-Draft                   Brotli                       April 2015
       82e0a4b0e0a4abe0a4bce0a58de0a4a4e0a4bee0a4b0e0a4a8e0a4bfe0a4b0e0
       a58de0a4aee0a4bee0a4a3e0a4b2e0a4bfe0a4aee0a4bfe0a49fe0a587e0a4a1
       6465736372697074696f6e2220636f6e74656e743d22646f63756d656e742e6c
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 112]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6f636174696f6e2e70726f742e676574456c656d656e747342795461674e616d
       65283c21444f43545950452068746d6c3e0a3c68746d6c203c6d657461206368
       61727365743d227574662d38223e3a75726c2220636f6e74656e743d22687474
@@ -6268,14 +6298,6 @@ Internet-Draft                   Brotli                       April 2015
       2230222063656c6c73706163696e673d223022207970653d22746578742f6373
       7322206d656469613d22747970653d27746578742f6a61766173637269707427
       776974682074686520657863657074696f6e206f66207970653d22746578742f
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 112]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       637373222072656c3d227374206865696768743d2231222077696474683d2231
       22203d272b656e636f6465555249436f6d706f6e656e74283c6c696e6b207265
       6c3d22616c7465726e61746522200a626f64792c2074722c20696e7075742c20
@@ -6302,6 +6324,14 @@ Internet-Draft                   Brotli                       April 2015
       436f6e746572616e736974696f6e616c2f2f454e222022687474703a3c68746d
       6c20786d6c6e733d22687474703a2f2f7777772d2f2f5733432f2f4454442058
       48544d4c20312e3020544454442f7868746d6c312d7472616e736974696f6e61
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 113]
+
+Internet-Draft                   Brotli                       April 2015
+
+
       6c2f2f7777772e77332e6f72672f54522f7868746d6c312f7065203d20277465
       78742f6a617661736372697074273b3c6d657461206e616d653d226465736372
       697074696f6e706172656e744e6f64652e696e736572744265666f72653c696e
@@ -6324,14 +6354,6 @@ Internet-Draft                   Brotli                       April 2015
       22646973706c61793a6e6f6e653b223e646f63756d656e742e676574456c656d
       656e7442794964283d646f63756d656e742e637265617465456c656d656e7428
       2720747970653d27746578742f6a61766173637269707427696e707574207479
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 113]
-
-Internet-Draft                   Brotli                       April 2015
-
-
       70653d227465787422206e616d653d22642e676574456c656d656e7473427954
       61674e616d6528736e6963616c2220687265663d22687474703a2f2f7777772e
       432f2f4454442048544d4c20342e3031205472616e7369743c7374796c652074
@@ -6358,6 +6380,14 @@ Internet-Draft                   Brotli                       April 2015
 
       NDBITS :=  0,  0,  0,  0, 10, 10, 11, 11, 10, 10,
                 10, 10, 10,  9,  9,  8,  7,  7,  8,  7,
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 114]
+
+Internet-Draft                   Brotli                       April 2015
+
+
                  7,  6,  6,  5,  5
 
 Appendix B. List of word transformations
@@ -6380,14 +6410,6 @@ zlib CRC is 0x00f1fd60.
        --       ------     ---------            ------
         0           ""     Identity                 ""
         1           ""     Identity                " "
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 114]
-
-Internet-Draft                   Brotli                       April 2015
-
-
         2          " "     Identity                " "
         3           ""     OmitFirst1               ""
         4           ""     UppercaseFirst          " "
@@ -6414,6 +6436,14 @@ Internet-Draft                   Brotli                       April 2015
        25           ""     Identity            " for "
        26           ""     OmitFirst3               ""
        27           ""     OmitLast2                ""
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 115]
+
+Internet-Draft                   Brotli                       April 2015
+
+
        28           ""     Identity              " a "
        29           ""     Identity           " that "
        30          " "     UppercaseFirst           ""
@@ -6436,14 +6466,6 @@ Internet-Draft                   Brotli                       April 2015
        47           ""     Identity             " is "
        48           ""     OmitLast7                ""
        49           ""     OmitLast1            "ing "
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 115]
-
-Internet-Draft                   Brotli                       April 2015
-
-
        50           ""     Identity             "\n\t"
        51           ""     Identity                ":"
        52          " "     Identity               ". "
@@ -6470,6 +6492,14 @@ Internet-Draft                   Brotli                       April 2015
        73      " the "     Identity         " of the "
        74           ""     UppercaseFirst          "'"
        75           ""     Identity          ". This "
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 116]
+
+Internet-Draft                   Brotli                       April 2015
+
+
        76           ""     Identity                ","
        77          "."     Identity                " "
        78           ""     UppercaseFirst          "("
@@ -6492,14 +6522,6 @@ Internet-Draft                   Brotli                       April 2015
        95           ""     Identity             "est "
        96          " "     UppercaseFirst          "."
        97           ""     UppercaseAll          "\">"
-
-
-
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 116]
-
-Internet-Draft                   Brotli                       April 2015
-
-
        98          " "     Identity               "='"
        99           ""     UppercaseFirst          ","
       100           ""     Identity             "ize "
@@ -6527,6 +6549,13 @@ Internet-Draft                   Brotli                       April 2015
 
 Authors' Addresses
 
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 117]
+
+Internet-Draft                   Brotli                       April 2015
+
+
    Jyrki Alakuijala
    Google, Inc
 
@@ -6551,5 +6580,32 @@ Authors' Addresses
 
 
 
-Alakuijala & Szabadka   Expires October 27, 2015              [Page 117]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Alakuijala & Szabadka   Expires October 27, 2015              [Page 118]
 

--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -190,6 +190,9 @@ BrotliCompressor::BrotliCompressor(BrotliParams params)
   if (params_.lgwin == 16) {
     last_byte_ = 0;
     last_byte_bits_ = 1;
+  } else if (params_.lgwin == 17) {
+    last_byte_ = 1;
+    last_byte_bits_ = 7;
   } else {
     last_byte_ = ((params_.lgwin - 17) << 1) | 1;
     last_byte_bits_ = 4;

--- a/enc/encode_parallel.cc
+++ b/enc/encode_parallel.cc
@@ -231,6 +231,9 @@ bool WriteMetaBlockParallel(const BrotliParams& params,
     if (params.lgwin == 16) {
       first_byte = 0;
       first_byte_bits = 1;
+    } else if (params.lgwin == 17) {
+      first_byte = 1;
+      first_byte_bits = 7;
     } else {
       first_byte = ((params.lgwin - 17) << 1) | 1;
       first_byte_bits = 4;


### PR DESCRIPTION
The previous window bit value 17 is used to
extend the range, since it has not been used
in any previous encoders.