### PR TITLE
[python] fix compatibility_test.py with Python 3

### DIFF
--- a/python/tests/compatibility_test.py
+++ b/python/tests/compatibility_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 import glob
-import string
 import sys
 import os
 from subprocess import check_call
@@ -13,7 +12,7 @@ os.chdir(os.path.abspath("../../tests"))
 for filename in glob.glob("testdata/*.compressed*"):
     filename = os.path.abspath(filename)
     print('Testing decompression of file "%s"' % os.path.basename(filename))
-    expected = string.split(filename, ".compressed")[0]
+    expected = filename.split(".compressed")[0]
     uncompressed = expected + ".uncompressed"
     check_call([PYTHON, BRO, "-f", "-d", "-i", filename, "-o", uncompressed],
                env=TEST_ENV)


### PR DESCRIPTION
the compatibility_test.py raises AttributeError in Python 3, because it tries to use the "split" function from the "string" module, but that's no longer available in Python 3.
We should use the built-in str.split() method of string objects, which works the same in Python 2 and 3.


```python
Traceback (most recent call last):
  File "compatibility_test.py", line 16, in <module>
    expected = string.split(filename, ".compressed")[0]
AttributeError: 'module' object has no attribute 'split'
```