### PR TITLE
Add a MODE_GENERIC compression mode to the interface.

### DIFF
--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -211,7 +211,8 @@ BrotliCompressor::BrotliCompressor(BrotliParams params)
     hash_type_ = (params_.mode == BrotliParams::MODE_TEXT) ? 10 : 11;
   }
   hashers_->Init(hash_type_);
-  if (params_.mode == BrotliParams::MODE_TEXT &&
+  if ((params_.mode == BrotliParams::MODE_GENERIC ||
+       params_.mode == BrotliParams::MODE_TEXT) &&
       params_.enable_dictionary) {
     StoreDictionaryWordHashes(params_.enable_transforms);
   }

--- a/enc/encode.h
+++ b/enc/encode.h
@@ -36,7 +36,7 @@ static const int kMaxInputBlockBits = 24;
 
 struct BrotliParams {
   BrotliParams()
-      : mode(MODE_TEXT),
+      : mode(MODE_GENERIC),
         quality(11),
         lgwin(22),
         lgblock(0),
@@ -46,8 +46,13 @@ struct BrotliParams {
         enable_context_modeling(true) {}
 
   enum Mode {
-    MODE_TEXT = 0,
-    MODE_FONT = 1,
+    // Default compression mode. The compressor does not know anything in
+    // advance about the properties of the input.
+    MODE_GENERIC = 0,
+    // Compression mode for UTF-8 format text input.
+    MODE_TEXT = 1,
+    // Compression mode used in WOFF 2.0.
+    MODE_FONT = 2,
   };
   Mode mode;
 


### PR DESCRIPTION
With this the users can distinguish between not knowing
what the input is (ddefault) and knowing that it is text,
and thus can be relied on to force some UTF-8 specific settings.