### PR TITLE
Use the same hasher for text and font mode.

### DIFF
--- a/enc/backward_references.cc
+++ b/enc/backward_references.cc
@@ -371,17 +371,10 @@ void CreateBackwardReferences(size_t num_bytes,
           commands, num_commands, num_literals);
       break;
     case 10:
-      CreateBackwardReferences<Hashers::H11Text, true, true>(
+      CreateBackwardReferences<Hashers::H10, true, true>(
           num_bytes, position, ringbuffer, ringbuffer_mask,
           literal_cost, literal_cost_mask, max_backward_limit, base_min_score,
-          quality, hashers->hash_h11_text.get(), dist_cache, last_insert_len,
-          commands, num_commands, num_literals);
-      break;
-    case 11:
-      CreateBackwardReferences<Hashers::H11Font, true, false>(
-          num_bytes, position, ringbuffer, ringbuffer_mask,
-          literal_cost, literal_cost_mask, max_backward_limit, base_min_score,
-          quality, hashers->hash_h11_font.get(), dist_cache, last_insert_len,
+          quality, hashers->hash_h10.get(), dist_cache, last_insert_len,
           commands, num_commands, num_literals);
       break;
     default:

--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -208,7 +208,7 @@ BrotliCompressor::BrotliCompressor(BrotliParams params)
   if (params_.quality <= 9) {
     hash_type_ = params_.quality;
   } else {
-    hash_type_ = (params_.mode == BrotliParams::MODE_TEXT) ? 10 : 11;
+    hash_type_ = 10;
   }
   hashers_->Init(hash_type_);
   if ((params_.mode == BrotliParams::MODE_GENERIC ||


### PR DESCRIPTION
We use 4-byte hashing in both and look for length 3
matches separately.