### PR TITLE
Speedups to brotli quality 11.

### DIFF
--- a/enc/block_splitter.cc
+++ b/enc/block_splitter.cc
@@ -150,8 +150,8 @@ void RefineEntropyCodes(const DataType* data, size_t length,
   }
 }
 
-inline static float BitCost(int total, int count) {
-  return count == 0 ? FastLog2(total) + 2 : FastLog2(total) - FastLog2(count);
+inline static float BitCost(int count) {
+  return count == 0 ? -2 : FastLog2(count);
 }
 
 template<typename DataType, int kSize>
@@ -168,10 +168,12 @@ void FindBlocks(const DataType* data, const size_t length,
   int vecsize = vec.size();
   double* insert_cost = new double[kSize * vecsize];
   memset(insert_cost, 0, sizeof(insert_cost[0]) * kSize * vecsize);
-  for (int i = 0; i < kSize; ++i) {
+  for (int j = 0; j < vecsize; ++j) {
+    insert_cost[j] = FastLog2(vec[j].total_count_);
+  }
+  for (int i = kSize - 1; i >= 0; --i) {
     for (int j = 0; j < vecsize; ++j) {
-      insert_cost[i * vecsize + j] =
-          BitCost(vec[j].total_count_, vec[j].data_[i]);
+      insert_cost[i * vecsize + j] = insert_cost[j] - BitCost(vec[j].data_[i]);
     }
   }
   double *cost = new double[vecsize];

--- a/enc/brotli_bit_stream.cc
+++ b/enc/brotli_bit_stream.cc
@@ -393,37 +393,6 @@ void RunLengthCodeZeros(const std::vector<int>& v_in,
   }
 }
 
-// Returns a maximum zero-run-length-prefix value such that run-length coding
-// zeros in v with this maximum prefix value and then encoding the resulting
-// histogram and entropy-coding v produces the least amount of bits.
-int BestMaxZeroRunLengthPrefix(const std::vector<int>& v) {
-  int min_cost = std::numeric_limits<int>::max();
-  int best_max_prefix = 0;
-  for (int max_prefix = 0; max_prefix <= 16; ++max_prefix) {
-    std::vector<int> rle_symbols;
-    std::vector<int> extra_bits;
-    int max_run_length_prefix = max_prefix;
-    RunLengthCodeZeros(v, &max_run_length_prefix, &rle_symbols, &extra_bits);
-    if (max_run_length_prefix < max_prefix) break;
-    HistogramContextMap histogram;
-    for (int i = 0; i < rle_symbols.size(); ++i) {
-      histogram.Add(rle_symbols[i]);
-    }
-    int bit_cost = PopulationCost(histogram);
-    if (max_prefix > 0) {
-      bit_cost += 4;
-    }
-    for (int i = 1; i <= max_prefix; ++i) {
-      bit_cost += histogram.data_[i] * i;  // extra bits
-    }
-    if (bit_cost < min_cost) {
-      min_cost = bit_cost;
-      best_max_prefix = max_prefix;
-    }
-  }
-  return best_max_prefix;
-}
-
 void EncodeContextMap(const std::vector<int>& context_map,
                       int num_clusters,
                       int* storage_ix, uint8_t* storage) {
@@ -436,7 +405,7 @@ void EncodeContextMap(const std::vector<int>& context_map,
   std::vector<int> transformed_symbols = MoveToFrontTransform(context_map);
   std::vector<int> rle_symbols;
   std::vector<int> extra_bits;
-  int max_run_length_prefix = BestMaxZeroRunLengthPrefix(transformed_symbols);
+  int max_run_length_prefix = 6;
   RunLengthCodeZeros(transformed_symbols, &max_run_length_prefix,
                      &rle_symbols, &extra_bits);
   HistogramContextMap symbol_histogram;

--- a/enc/cluster.h
+++ b/enc/cluster.h
@@ -279,13 +279,12 @@ void ClusterHistograms(const std::vector<HistogramType>& in,
     (*histogram_symbols)[i] = i;
   }
 
-  // Collapse similar histograms within a block type.
-  if (num_contexts > 1) {
-    for (int i = 0; i < num_blocks; ++i) {
-      HistogramCombine(&(*out)[0], &cluster_size[0],
-                       &(*histogram_symbols)[i * num_contexts], num_contexts,
-                       max_histograms);
-    }
+  const int max_input_histograms = 64;
+  for (int i = 0; i < in_size; i += max_input_histograms) {
+    int num_to_combine = std::min(in_size - i, max_input_histograms);
+    HistogramCombine(&(*out)[0], &cluster_size[0],
+                     &(*histogram_symbols)[i], num_to_combine,
+                     max_histograms);
   }
 
   // Collapse similar histograms.


### PR DESCRIPTION
  * Cluster at most 64 histograms at a time in the first
    round of clustering.

  * Use a faster histogram cost estimation function.

  * Don't compute the log2(total) multiple times in the
    block splitter.