### PR TITLE
Brotli custom LZ77 dictionary support.

### DIFF
--- a/dec/bit_reader.h
+++ b/dec/bit_reader.h
@@ -97,19 +97,6 @@ static BROTLI_INLINE uint32_t BrotliPrefetchBits(BrotliBitReader* const br) {
   return (uint32_t)(br->val_ >> br->bit_pos_);
 }
 
-/* For jumping over a number of bits in the bit stream when accessed with */
-/* BrotliPrefetchBits and BrotliFillBitWindow. */
-static BROTLI_INLINE void BrotliSetBitPos(BrotliBitReader* const br,
-                                          uint32_t val) {
-#ifdef BROTLI_DECODE_DEBUG
-  uint32_t n_bits = val - br->bit_pos_;
-  const uint32_t bval = (uint32_t)(br->val_ >> br->bit_pos_) & BitMask(n_bits);
-  printf("[BrotliReadBits]  %010d %2d  val: %6x\n",
-         (br->pos_ << 3) + br->bit_pos_ - 64, n_bits, bval);
-#endif
-  br->bit_pos_ = val;
-}
-
 /*
  * Reload up to 32 bits byte-by-byte.
  * This function works on both little and big endian.

--- a/dec/decode.h
+++ b/dec/decode.h
@@ -123,6 +123,19 @@ BrotliResult BrotliDecompressBufferStreaming(size_t* available_in,
                                              size_t* total_out,
                                              BrotliState* s);
 
+/* Fills the new state with a dictionary for LZ77, warming up the ringbuffer,
+   e.g. for custom static dictionaries for data formats.
+   Not to be confused with the built-in transformable dictionary of Brotli.
+   The dictionary must exist in memory until decoding is done and is owned by
+   the caller. To use:
+   -initialize state with BrotliStateInit
+   -use BrotliSetCustomDictionary
+   -use BrotliDecompressBufferStreaming
+   -clean up with BrotliStateCleanup
+*/
+void BrotliSetCustomDictionary(
+    size_t size, const uint8_t* dict, BrotliState* s);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 } /* extern "C" */
 #endif

--- a/dec/state.c
+++ b/dec/state.c
@@ -46,6 +46,9 @@ void BrotliStateInit(BrotliState* s) {
 
   s->code_lengths = NULL;
   s->context_map_table = NULL;
+
+  s->custom_dict = NULL;
+  s->custom_dict_size = 0;
 }
 
 void BrotliStateCleanup(BrotliState* s) {

--- a/dec/state.h
+++ b/dec/state.h
@@ -167,6 +167,10 @@ typedef struct {
   int context_index;
   int max_run_length_prefix;
   HuffmanCode* context_map_table;
+
+  /* For custom dictionaries */
+  const uint8_t* custom_dict;
+  int custom_dict_size;
 } BrotliState;
 
 void BrotliStateInit(BrotliState* s);

--- a/enc/encode.h
+++ b/enc/encode.h
@@ -128,6 +128,13 @@ class BrotliCompressor {
   bool WriteBrotliData(const bool is_last, const bool force_flush,
                        size_t* out_size, uint8_t** output);
 
+  // Fills the new state with a dictionary for LZ77, warming up the ringbuffer,
+  // e.g. for custom static dictionaries for data formats.
+  // Not to be confused with the built-in transformable dictionary of Brotli.
+  // To decode, use BrotliSetCustomDictionary of the decoder with the same
+  // dictionary.
+  void BrotliSetCustomDictionary(size_t size, const uint8_t* dict);
+
   // No-op, but we keep it here for API backward-compatibility.
   void WriteStreamHeader() {}
 
@@ -179,6 +186,12 @@ int BrotliCompressBuffer(BrotliParams params,
 // Same as above, but uses the specified input and output classes instead
 // of reading from and writing to pre-allocated memory buffers.
 int BrotliCompress(BrotliParams params, BrotliIn* in, BrotliOut* out);
+
+// Before compressing the data, sets a custom LZ77 dictionary with
+// BrotliCompressor::BrotliSetCustomDictionary.
+int BrotliCompressWithCustomDictionary(size_t dictsize, const uint8_t* dict,
+                                       BrotliParams params,
+                                       BrotliIn* in, BrotliOut* out);
 
 }  // namespace brotli
 

--- a/enc/hash.h
+++ b/enc/hash.h
@@ -612,6 +612,31 @@ struct Hashers {
     if (hash_h10.get() != NULL) hash_h10->SetStaticDictionary(dict);
   }
 
+  template<typename Hasher>
+  void WarmupHash(const size_t size, const uint8_t* dict, Hasher* hasher) {
+    for (size_t i = 0; i < size; i++) {
+      hasher->Store(dict, i);
+    }
+  }
+
+  // Custom LZ77 window.
+  void PrependCustomDictionary(
+      int type, const size_t size, const uint8_t* dict) {
+    switch (type) {
+      case 1: WarmupHash(size, dict, hash_h1.get()); break;
+      case 2: WarmupHash(size, dict, hash_h2.get()); break;
+      case 3: WarmupHash(size, dict, hash_h3.get()); break;
+      case 4: WarmupHash(size, dict, hash_h4.get()); break;
+      case 5: WarmupHash(size, dict, hash_h5.get()); break;
+      case 6: WarmupHash(size, dict, hash_h6.get()); break;
+      case 7: WarmupHash(size, dict, hash_h7.get()); break;
+      case 8: WarmupHash(size, dict, hash_h8.get()); break;
+      case 9: WarmupHash(size, dict, hash_h9.get()); break;
+      case 10: WarmupHash(size, dict, hash_h10.get()); break;
+      default: break;
+    }
+  }
+
   std::unique_ptr<H1> hash_h1;
   std::unique_ptr<H2> hash_h2;
   std::unique_ptr<H3> hash_h3;


### PR DESCRIPTION
Adds functions to prepend such dictionary to the
encoder and decoder, and twiddles their internal
parameters to do as if that was a previous part of
the input. This dictionary is just a prefilled LZ77
window, it is not related to the built in transformable
brotli dictionary.