### PR TITLE
Bug fixes for the brotli encoder.

### DIFF
--- a/enc/bit_cost.h
+++ b/enc/bit_cost.h
@@ -91,6 +91,9 @@ double PopulationCost(const Histogram<kSize>& histogram) {
       // Approximate the bit depth by round(-log2(P(symbol)))
       int depth = static_cast<int>(log2p + 0.5);
       bits += histogram.data_[i] * log2p;
+      if (depth > 15) {
+        depth = 15;
+      }
       if (depth > max_depth) {
         max_depth = depth;
       }

--- a/enc/block_splitter.cc
+++ b/enc/block_splitter.cc
@@ -74,7 +74,7 @@ void CopyLiteralsToByteArray(const Command* cmds,
 void CopyCommandsToByteArray(const Command* cmds,
                              const size_t num_commands,
                              std::vector<uint16_t>* insert_and_copy_codes,
-                             std::vector<uint8_t>* distance_prefixes) {
+                             std::vector<uint16_t>* distance_prefixes) {
   for (int i = 0; i < num_commands; ++i) {
     const Command& cmd = cmds[i];
     insert_and_copy_codes->push_back(cmd.cmd_prefix_);
@@ -356,7 +356,7 @@ void SplitBlock(const Command* cmds,
 
   // Compute prefix codes for commands.
   std::vector<uint16_t> insert_and_copy_codes;
-  std::vector<uint8_t> distance_prefixes;
+  std::vector<uint16_t> distance_prefixes;
   CopyCommandsToByteArray(cmds, num_commands,
                           &insert_and_copy_codes,
                           &distance_prefixes);

--- a/enc/encode.h
+++ b/enc/encode.h
@@ -165,6 +165,7 @@ class BrotliCompressor {
   size_t last_flush_pos_;
   size_t last_processed_pos_;
   int dist_cache_[4];
+  int saved_dist_cache_[4];
   uint8_t last_byte_;
   uint8_t last_byte_bits_;
   uint8_t prev_byte_;

--- a/enc/entropy_encode.h
+++ b/enc/entropy_encode.h
@@ -40,7 +40,7 @@ void CreateHuffmanTree(const int *data,
                        uint8_t *depth);
 
 // Change the population counts in a way that the consequent
-// Hufmann tree compression, especially its rle-part will be more
+// Huffman tree compression, especially its rle-part will be more
 // likely to compress this data more efficiently.
 //
 // length contains the size of the histogram.

--- a/enc/histogram.h
+++ b/enc/histogram.h
@@ -59,13 +59,6 @@ struct Histogram {
       data_[i] += v.data_[i];
     }
   }
-  double EntropyBitCost() const {
-    double retval = total_count_ * FastLog2(total_count_);
-    for (int i = 0; i < kDataSize; ++i) {
-      retval -= data_[i] * FastLog2(data_[i]);
-    }
-    return retval;
-  }
 
   int data_[kDataSize];
   int total_count_;

--- a/enc/port.h
+++ b/enc/port.h
@@ -17,6 +17,8 @@
 #ifndef BROTLI_ENC_PORT_H_
 #define BROTLI_ENC_PORT_H_
 
+#include <string.h>
+
 #if defined OS_LINUX || defined OS_CYGWIN
 #include <endian.h>
 #elif defined OS_FREEBSD


### PR DESCRIPTION
  * Fix an out-of-bounds access to depth_histo in the
    bit cost calculation function.

  * Change type of distance symbol to uint16_t in block
    splitter, because if all postfix bits are used, there
    can be 520 distance symbols.

  * Save the distance cache between meta-blocks at the
    correct place. This fixes a roundtrip failure that
    can occur when there is an uncompressed metablock
    between two compressed metablocks.

  * Fix a bug when setting lgwin to 24 in the encoder parameters
    It ended up making metablocks larger than 24 bits in size.

  * Fix out-of-bounds memory accesses in parallel encoder.
    CreateBackwardReferences can read up to 4 bytes past end of
    input if the end of input is before mask.

  * Add missing header for memcpy() in port.h