### PR TITLE
Fix vs2010

### DIFF
--- a/enc/backward_references.cc
+++ b/enc/backward_references.cc
@@ -17,13 +17,14 @@
 #include "./backward_references.h"
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "./command.h"
 
 namespace brotli {
 
-static const double kInfinity = 1.0 / 0.0;
+static const double kInfinity = std::numeric_limits<double>::infinity();
 
 // Histogram based cost model for zopflification.
 class ZopfliCostModel {

--- a/enc/backward_references.cc
+++ b/enc/backward_references.cc
@@ -20,6 +20,7 @@
 #include <limits>
 #include <vector>
 
+#include "./fast_log.h"
 #include "./command.h"
 
 namespace brotli {
@@ -137,12 +138,12 @@ class ZopfliCostModel {
     }
     for (size_t i = 0; i < histogram.size(); i++) {
       if (histogram[i] == 0) {
-        (*cost)[i] = -log2(0.25 / sum);
+        (*cost)[i] = -_log2(0.25 / sum);
         continue;
       }
 
       // Shannon bits for this symbol.
-      (*cost)[i] = -log2(histogram[i] / sum);
+      (*cost)[i] = -_log2(histogram[i] / sum);
 
       // Cannot be coded with less than 1 bit
       if ((*cost)[i] < 1) (*cost)[i] = 1;

--- a/enc/fast_log.h
+++ b/enc/fast_log.h
@@ -159,19 +159,23 @@ static const float kLog2Table[] = {
   7.9943534368588578f
 };
 
+// Visual Studio 2010 does not have the log2() function defined, so we use
+// log() and a multiplication instead.
+static inline double _log2(double v) {
+#if defined(_MSC_VER) && _MSC_VER <= 1600
+  static const double kLog2Inv = 1.4426950408889634f;
+  return log(v) * kLog2Inv;
+#else
+  return log2(v);
+#endif
+}
+
 // Faster logarithm for small integers, with the property of log2(0) == 0.
 static inline double FastLog2(int v) {
-  if (v < (int)(sizeof(kLog2Table) / sizeof(kLog2Table[0]))) {
+  if (v < (int)(sizeof(kLog2Table) / sizeof(kLog2Table[0])))
     return kLog2Table[v];
-  }
-#if defined(_MSC_VER) && _MSC_VER <= 1600
-  // Visual Studio 2010 does not have the log2() function defined, so we use
-  // log() and a multiplication instead.
-  static const double kLog2Inv = 1.4426950408889634f;
-  return log(static_cast<double>(v)) * kLog2Inv;
-#else
-  return log2(static_cast<double>(v));
-#endif
+  else
+    return _log2(static_cast<double>(v));
 }
 
 }  // namespace brotli


### PR DESCRIPTION
I get the following errors on Windows using Visual Studio 2010 when trying to compile the Python extension:

```
enc/backward_references.cc(26) : error C2124: divide or mod by zero
enc/backward_references.cc(140) : error C3861: 'log2': identifier not found
enc/backward_references.cc(145) : error C3861: 'log2': identifier not found
```

The patch tries to fix both issues.

For the `kInfinity` constant, I use `std::numeric_limits::infinity` as found in the `<limits>` header.

For the `log2` function (missing from Visual Studio 2010) which is used in `backward_references.cc`, I define a new `_log2` function inside `fast_log.h`. This MSVC specific workaround was previously incorporated in the `FastLog2` function, so I just extracted it from there.

We need to support Visual Studio 2010, otherwise it's not possible to compile the Python extension for Windows (Python 3.4 for Windows from Python.org is still built using Visual Studio 2010).

Cheers,

Cosimo