### PR TITLE
fix compilation on Windows Python 2.7 + support for MINGW32 and Cygwin

### DIFF
--- a/python/bro.py
+++ b/python/bro.py
@@ -9,9 +9,6 @@ import brotli
 import platform
 
 
-__version__ = '1.0'
-
-
 # default values of encoder parameters
 DEFAULT_PARAMS = {
     'mode': brotli.MODE_GENERIC,
@@ -54,7 +51,7 @@ def main():
     parser = argparse.ArgumentParser(
         prog='bro.py',
         description="Compression/decompression utility using the Brotli algorithm.")
-    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
+    parser.add_argument('--version', action='version', version=brotli.__version__)
     parser.add_argument('-i', '--input', metavar='FILE', type=str, dest='infile',
                         help='Input file', default=None)
     parser.add_argument('-o', '--output', metavar='FILE', type=str, dest='outfile',

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -110,7 +110,7 @@ static PyObject* brotli_compress(PyObject *self, PyObject *args, PyObject *keywd
   int lgblock = -1;
   int ok;
 
-  static const char *kwlist[] = {"string", "mode", "quality", "lgwin", "lgblock"};
+  static const char *kwlist[] = {"string", "mode", "quality", "lgwin", "lgblock", NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "s#|O&O&O&O&:compress",
                         const_cast<char **>(kwlist),

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -9,6 +9,8 @@
 #define PyInt_AsLong PyLong_AsLong
 #endif
 
+#define BROTLI_VERSION "0.1.0"
+
 using namespace brotli;
 
 static PyObject *BrotliError;
@@ -242,6 +244,8 @@ PyMODINIT_FUNC INIT_BROTLI(void) {
   PyModule_AddIntConstant(m, "MODE_GENERIC", (int) BrotliParams::Mode::MODE_GENERIC);
   PyModule_AddIntConstant(m, "MODE_TEXT", (int) BrotliParams::Mode::MODE_TEXT);
   PyModule_AddIntConstant(m, "MODE_FONT", (int) BrotliParams::Mode::MODE_FONT);
+
+  PyModule_AddStringConstant(m, "__version__", BROTLI_VERSION);
 
   RETURN_BROTLI;
 }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,22 @@
+import distutils
 from distutils.core import setup, Extension
 from distutils.command.build_ext import build_ext
 from distutils.cmd import Command
 import platform
+
+
+# when compiling for Windows Python 2.7, force distutils to use Visual Studio
+# 2010 instead of 2008, as the latter doesn't support c++0x
+if platform.system() == 'Windows':
+    try:
+        import distutils.msvc9compiler
+    except distutils.errors.DistutilsPlatformError:
+        pass  # importing msvc9compiler raises when running under MinGW
+    else:
+        orig_find_vcvarsall = distutils.msvc9compiler.find_vcvarsall
+        def patched_find_vcvarsall(version):
+            return orig_find_vcvarsall(version if version != 9.0 else 10.0)
+        distutils.msvc9compiler.find_vcvarsall = patched_find_vcvarsall
 
 
 class TestCommand(Command):


### PR DESCRIPTION
This includes:

- a patch to `setup.py` to force `distutils` use MS Visual C++ 10.0, from Visual Studio 2010, instead of the default 9.0, Visual Studio 2008, when compiling for **Windows Python 2.7**. The latter does not support many of the modern C++ features required to compile the Brotli encoder. Windows Python version 3 and above are compiled with 2010 so they are ok.

- two patches to `setup.py` to allow building Brotli with GCC for Windows, instead of the default Microsoft compiler. This can be done by passing the `--compiler=mingw32` option to setup.py.

- a patch to `streams.cc` to fix compilation under the Cygwin environment. Here GCC complains that 'malloc' and 'free' weren't declared in the current scope:

```
enc/streams.cc: In constructor ‘brotli::BrotliFileIn::BrotliFileIn(FILE*, size_t)’:
enc/streams.cc:92:32: error: ‘malloc’ was not declared in this scope
       buf_(malloc(max_read_size)),
                                ^
enc/streams.cc: In destructor ‘virtual brotli::BrotliFileIn::~BrotliFileIn()’:
enc/streams.cc:96:22: error: ‘free’ was not declared in this scope
   if (buf_) free(buf_);
                      ^
error: command 'gcc' failed with exit status 1
```