### PR TITLE
fix RuntimeError by terminating kwlist with NULL pointer

### DIFF
--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -110,7 +110,7 @@ static PyObject* brotli_compress(PyObject *self, PyObject *args, PyObject *keywd
   int lgblock = -1;
   int ok;
 
-  static const char *kwlist[] = {"string", "mode", "quality", "lgwin", "lgblock"};
+  static const char *kwlist[] = {"string", "mode", "quality", "lgwin", "lgblock", NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "s#|O&O&O&O&:compress",
                         const_cast<char **>(kwlist),


### PR DESCRIPTION
The `<malloc.h>` header is non-standard, and causes compilation error on OS X:
```
dec/decode.c:16:10: fatal error: 'malloc.h' file not found
#include <malloc.h>
         ^
1 error generated.
error: command 'clang' failed with exit status 1
```
Just including `<stdlib.h>` should be sufficient in this case.

I also realised that I broke the `brotli.compress` function in #131... at least on OS X, running the tests raises:
```
RuntimeError: More keyword list entries (10) than format specifiers (5)
```
That's because I forgot to terminate the `kwlist` array with `NULL` pointer.
Sorry about that.

Strangely enough this error doesn't occur on Windows.

That's one more reason to have continuous integration systems like Travis/Appveyor running tests on multiple platforms. As a bonus, we could have them automatically build Python wheels for both Win and Mac, and deploying them to Github Releases every time a new release is tagged.
I'll send a specific PR for that soon.
