### PR TITLE
support building compiled wheels packages using Appveyor + Travis 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "terryfy"]
+	path = terryfy
+	url = https://github.com/MacPython/terryfy.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language:
 env:
   matrix:
   - INSTALL_TYPE='system' VERSION=2.7
+  - INSTALL_TYPE='macpython' VERSION=2.7.10 CC=clang CXX=clang++
+  - INSTALL_TYPE='macpython' VERSION=3.4.3 CC=clang CXX=clang++
   - INSTALL_TYPE='homebrew' VERSION=2.7.10
   - INSTALL_TYPE='homebrew' VERSION=3.4.3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language:
+- objective-c
+env:
+  matrix:
+  - INSTALL_TYPE='system' VERSION=2.7
+  - INSTALL_TYPE='homebrew' VERSION=2.7.9
+  - INSTALL_TYPE='homebrew' VERSION=3.4.3
+install:
+- source terryfy/travis_tools.sh
+- get_python_environment $INSTALL_TYPE $VERSION venv
+- pip install --upgrade wheel
+script:
+- python setup.py build_ext test
+after_success:
+- pip wheel -w dist .
+before_deploy:
+- cd dist
+- "wheels=$(echo *.whl)"
+#deploy:
+# - TODO: upload the content of $wheels to a public wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language:
 env:
   matrix:
   - INSTALL_TYPE='system' VERSION=2.7
-  - INSTALL_TYPE='homebrew' VERSION=2.7.9
+  - INSTALL_TYPE='homebrew' VERSION=2.7.10
   - INSTALL_TYPE='homebrew' VERSION=3.4.3
 install:
 - source terryfy/travis_tools.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+environment:
+
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.1"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.1"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+  # install Python and pip when not already installed
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # prepend newly installed Python to the PATH
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # upgrade pip to avoid out-of-date warnings
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  # install wheel to build compiled packages
+  - "pip install --upgrade wheel"
+
+build: false
+
+test_script:
+  - "%WITH_COMPILER% python setup.py build_ext test"
+
+after_test:
+  # if tests are successful, create binary packages for the project
+  - "%WITH_COMPILER% pip wheel -w dist ."
+
+artifacts:
+  # archive the generated packages in the ci.appveyor.com build report
+  - path: dist\*
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,85 @@
+# Sample script to install Python and pip under Windows
+# Authors: Olivier Grisel and Kyle Kastner
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$BASE_URL = "https://www.python.org/ftp/python/"
+$GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+$GET_PIP_PATH = "C:\get-pip.py"
+
+
+function DownloadPython ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "python-" + $python_version + $platform_suffix + ".msi"
+    $url = $BASE_URL + $python_version + "/" + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 5 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 3
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   Write-Host "File saved at" $filepath
+   return $filepath
+}
+
+
+function InstallPython ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = ""
+    } else {
+        $platform_suffix = ".amd64"
+    }
+    $filepath = DownloadPython $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $args = "/qn /i $filepath TARGETDIR=$python_home"
+    Write-Host "msiexec.exe" $args
+    Start-Process -FilePath "msiexec.exe" -ArgumentList $args -Wait -Passthru
+    Write-Host "Python $python_version ($architecture) installation complete"
+    return $true
+}
+
+
+function InstallPip ($python_home) {
+    $pip_path = $python_home + "/Scripts/pip.exe"
+    $python_path = $python_home + "/python.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+        Write-Host "Executing:" $python_path $GET_PIP_PATH
+        Start-Process -FilePath "$python_path" -ArgumentList "$GET_PIP_PATH" -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+function InstallPackage ($python_home, $pkg) {
+    $pip_path = $python_home + "/Scripts/pip.exe"
+    & $pip_path install $pkg
+}
+
+function main () {
+    InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallPip $env:PYTHON
+    InstallPackage $env:PYTHON wheel
+}
+
+main

--- a/appveyor/run_with_compiler.cmd
+++ b/appveyor/run_with_compiler.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,8 @@ class BuildExt(build_ext):
         objects = []
         for lang, sources in (("c", c_sources), ("c++", cxx_sources)):
             if lang == "c++": 
+                if platform.system() == "Darwin":
+                    extra_args.extend(["-stdlib=libc++", "-mmacosx-version-min=10.7"])
                 if self.compiler.compiler_type in ["unix", "cygwin", "mingw32"]:
                     extra_args.append("-std=c++0x")
                 elif self.compiler.compiler_type == "msvc":


### PR DESCRIPTION
Here's my attempt at using CI systems to run automated builds of Brotli Python extension module.

You can see the latest build logs here:
https://travis-ci.org/anthrotype/brotli
https://ci.appveyor.com/project/anthrotype/brotli

Only Windows (via Appveyor) and OS X (via Travis) are supported here.
PyPI does not accept precompiled Linux wheels anyway: see http://pythonwheels.com/

On Windows, I test both 32 and 64-bit Python, 2.7.x and 3.4.x. The extension is compiled using MSVC 2010.

On OS X, I use the [MacPython/terrify](https://github.com/MacPython/terryfy) utilities in order to download and configure different python setups.

I could successfully compile Brotli on Apple's system Python (2.7.x), as well as on Homebrew Python 2.7.10 and 3.4.3. However, I was not able to build Brotli using official Python installers from Python.org. The latter are compiled using OS X 10.6 SDK and GCC 4.2, which don't support advanced C++0x features required by Brotli.

We could configure both `appveyor.yml` and `.travis.yml` to deploy the compiled wheels to some public wheelhouse (even directly upload to PyPI) whenever a new release is tagged. 

E.g. http://docs.travis-ci.com/user/deployment/pypi/

Let me know what you think.
Thanks