### PR TITLE
[setup.py] pass extra compiler flags to clang on OS X to enable support for C+11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,8 @@ class BuildExt(build_ext):
         objects = []
         for lang, sources in (("c", c_sources), ("c++", cxx_sources)):
             if lang == "c++": 
+                if platform.system() == "Darwin":
+                    extra_args.extend(["-stdlib=libc++", "-mmacosx-version-min=10.7"])
                 if self.compiler.compiler_type in ["unix", "cygwin", "mingw32"]:
                     extra_args.append("-std=c++0x")
                 elif self.compiler.compiler_type == "msvc":


### PR DESCRIPTION
This is for building the Brotli extension for Mac Python, i.e. the official OS X installers from Python.org.
(extracted from PR #136)