### PR TITLE
Travis support (OS X)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "terryfy"]
+	path = terryfy
+	url = https://github.com/MacPython/terryfy.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language:
 env:
   matrix:
   - INSTALL_TYPE='system' VERSION=2.7
+  - INSTALL_TYPE='macpython' VERSION=2.7.10 CC=clang CXX=clang++
+  - INSTALL_TYPE='macpython' VERSION=3.4.3 CC=clang CXX=clang++
   - INSTALL_TYPE='homebrew' VERSION=2.7.10
   - INSTALL_TYPE='homebrew' VERSION=3.4.3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language:
+- objective-c
+env:
+  matrix:
+  - INSTALL_TYPE='system' VERSION=2.7
+  - INSTALL_TYPE='homebrew' VERSION=2.7.10
+  - INSTALL_TYPE='homebrew' VERSION=3.4.3
+install:
+- source terryfy/travis_tools.sh
+- get_python_environment $INSTALL_TYPE $VERSION venv
+- pip install --upgrade wheel
+script:
+- python setup.py build_ext test
+after_success:
+- pip wheel -w dist .
+before_deploy:
+- cd dist
+- "wheels=$(echo *.whl)"
+#deploy:
+# - TODO: upload the content of $wheels to a public wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,17 @@ script:
 after_success:
 - pip wheel -w dist .
 before_deploy:
-- cd dist
-- "wheels=$(echo *.whl)"
-#deploy:
-# - TODO: upload the content of $wheels to a public wheelhouse
+- export WHEELS=$(ls ./dist/*.whl)
+
+# use `travis setup releases` to create a Github OAuth token
+# http://docs.travis-ci.com/user/deployment/releases/
+
+# deploy:
+#   provider: releases
+#   api_key: <encrypted Github OAuth token> 
+#   file:
+#     - "${WHEELS}"
+#   skip_cleanup: true
+#   on:
+#     repo: google/brotli
+#     tags: true


### PR DESCRIPTION
This adds a `.travis.yml` file which uses the [MacPython/terrify](https://github.com/MacPython/terryfy) utilities in order to run tests and compile wheels on different OS X Python setups.

After you enable google/brotli repository on your Travis account page, then you can configure the Github Releases deployment in the `.travis.yml` file. The easiest way to do that is installing travis locally, via `sudo gem install travis`, and then run `travis setup releases`.
More info here: http://docs.travis-ci.com/user/deployment/releases/

Please note that the Travis build will fail for the 'macpython' targets until PR #137 is merged.

