### PR TITLE
Cleanup redundant quality set

### DIFF
--- a/tools/bro.cc
+++ b/tools/bro.cc
@@ -191,7 +191,6 @@ int main(int argc, char** argv) {
       }
     } else {
       brotli::BrotliParams params;
-      params.quality = quality;
       brotli::BrotliFileIn in(fin, 1 << 16);
       brotli::BrotliFileOut out(fout);
       if (!BrotliCompress(params, &in, &out)) {


### PR DESCRIPTION
params.quality is already set by the ParseArgv on line 179