### PR TITLE
create 'brot' command-line compression program

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -6,11 +6,19 @@ BROTLI = ..
 ENCOBJ = $(BROTLI)/enc/*.o
 DECOBJ = $(BROTLI)/dec/*.o
 
-EXECUTABLES=bro
+EXECUTABLES=bro brot
 
 EXE_OBJS=$(patsubst %, %.o, $(EXECUTABLES))
 
-all : $(EXECUTABLES)
+all : $(EXECUTABLES) links
+
+tests: links brot
+	./brot-test.sh
+
+# Create hard-links for brot (similar to bzcat bunbzip2)
+links: brot
+	ln -f brot brotcat
+	ln -f brot unbrot
 
 $(EXECUTABLES) : $(EXE_OBJS) deps
 	$(CXX) $(LFLAGS) $(ENCOBJ) $(DECOBJ) $@.o -o $@

--- a/tools/brot-size-tests.sh
+++ b/tools/brot-size-tests.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# Copyright (C) 2015 Assaf Gordon (assafgordon@gmail.com)
+# License: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Test harness for 'brot' compression program,
+# compare compression sizes of different inputs with gzip/bzip2/xz
+
+set -e
+
+die()
+{
+    base=$(basename "$0")
+    echo "$base: error: $@" >&2
+    test -n "$D" && echo "$base: temp test directory: $D" >&2
+    exit 1
+}
+
+gen_random_num()
+{
+  N="$1"
+  shuf -n $N -i 1-1000000
+}
+
+gen_random_words()
+{
+  N="$1"
+  shuf -n $N /usr/share/dict/words
+}
+
+gen_random_bin()
+{
+  N="$1"
+  openssl enc -aes-256-ctr -pass pass:"42" \
+          -nosalt </dev/zero 2>/dev/null | head -c "$N"
+}
+
+## Test locally compiled brotli compression program
+for p in brot unbrot brotcat ; do
+    test -x "$p" \
+        || die "'$p' program not find in current directory " \
+               "(run 'make' to build it)"
+done
+export PATH=$CWD:$PATH
+
+D=$(mktemp -d test-brot-speed.XXXXXX) || die "failed to create temp dir"
+
+
+echo "Creating random data files in $D..."
+gen_random_num 1000    > $D/num1K || die "setup failed"
+gen_random_num 50000   > $D/num50K || die "setup failed"
+gen_random_num 100000  > $D/num100K || die "setup failed"
+gen_random_words 1000  > $D/words1K || die "setup failed"
+gen_random_words 5000  > $D/words5K || die "setup failed"
+gen_random_words 10000 > $D/words10K || die "setup failed"
+gen_random_bin 100K    > $D/bin100K || die "setup failed"
+gen_random_bin 1M      > $D/bin1M || die "setup failed"
+gen_random_bin 10M     > $D/bin10M || die "setup failed"
+
+# Compress all files
+# TODO: measure time?
+for i in $D/* ; do
+  for p in gzip bzip2 xz brot ; do
+    echo "running $p on $i..."
+    $p -k $i
+  done
+done
+
+# Show results
+printf "%-10s %10s %10s %10s %10s %10s\n" file size .gz .bz2 .xz .bro
+for f in num1K num50K num100K words1K words5K words10K bin100K bin1M bin10M ; do
+  # Sizes for different compressions
+  orig=$(stat -c %s $D/$f)
+  gz=$(  stat -c %s $D/$f.gz)
+  bz2=$( stat -c %s $D/$f.bz2)
+  xz=$(  stat -c %s $D/$f.xz)
+  bro=$( stat -c %s $D/$f.bro)
+
+  printf "%-10s %10s %10s %10s %10s %10s\n" $f $orig $gz $bz2 $xz $bro
+done
+
+rm -r "$D"

--- a/tools/brot-test.sh
+++ b/tools/brot-test.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+#
+# Copyright (C) 2015 Assaf Gordon (assafgordon@gmail.com)
+# License: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Test harness for 'brot' compression program,
+# compare it with the common usage of gzip/bzip2/xz .
+
+set -e
+
+die()
+{
+    base=$(basename "$0")
+    echo "$base: error: $@" >&2
+    test -n "$D" && echo "$base: temp test directory: $D" >&2
+    exit 1
+}
+
+## Test locally compiled brotli compression program
+for p in brot unbrot brotcat ; do
+    test -x "$p" \
+        || die "'$p' program not find in current directory " \
+               "(run 'make' to build it)"
+done
+export PATH=$CWD:$PATH
+
+
+# Run a small set of tests, exercising the most common usage pattern
+# for a unix compression program, e.g:
+#   comp FILE
+#   comp < FILE > OUTPUT
+#   comp FILE > OUTPUT
+#   comp -d FILE > OUTPUT
+#   comp -k FILE > OUTPUT
+#   decomp FILE > OUTPUT
+#   Xcat FILE > OUTPUT
+#
+# parameters:
+#   $1 = compression program (e.g. bzip2)
+#   $2 = decompression program (e.g. bunzip)
+#   $3 = decomp-cat program (e.g. bzcat)
+#   $4 = compressed file extension (e.g. 'bz2')
+#
+# dies on error with exit-code 1
+runtests()
+{
+  comp="$1"
+  decomp="$2"
+  cat="$3"
+  ext="$4"
+
+  D=$(mktemp -d test-$comp.XXXXXX) \
+      || die "failed to create temp test directory"
+
+  printf "hello world" > "$D/data"
+
+  # Compress stdin to stdout
+  $comp < $D/data > $D/out1.$ext || die "$comp - test 1 failed"
+
+  # decompress stdin to stdout
+  $comp -d < $D/out1.$ext > $D/out1 || die "$comp - test 2 failed"
+  cmp $D/data $D/out1 || die "$comp - test 3 failed"
+
+  # Compress a file to stdout (-c)
+  $comp -c $D/data > $D/out2.$ext || die "$comp - test 4 failed"
+
+  # Decompress and compare
+  $comp -d < $D/out2.$ext > $D/out3 || die "$comp - test 5 failed"
+  cmp $D/data $D/out3 || die "$comp - test 6 failed"
+
+  # Compress a file into a '.bro' file
+  $comp $D/data || die "$comp - test 8 failed"
+  # After compression, input file should not exist any more
+  test -e $D/data && die "$comp - test 9 failed"
+  # After compression, a '.bro' file should be created
+  test -e $D/data.$ext || die "$comp - test 10 failed"
+
+  # Decompress a '.bro' file into the original file
+  $comp -d $D/data.$ext || die "$comp - test 11 failed"
+  # After decompression, input file should not exist any more
+  test -e $D/data.$ext && die "$comp - test 12 failed"
+  # After decompression, the original input file name (without '.bro') should exist
+  test -e $D/data || die "$comp - test 13 failed"
+
+
+  # Compress and Keep the original
+  $comp -k $D/data || die "$comp - test 14 failed"
+  # After compression, original input file should STILL exist
+  test -e $D/data || die "$comp - test 15 failed"
+  # After compression, the compressed file sohuld also exist
+  test -e $D/data || die "$comp - test 16 failed"
+
+
+  # Decompress, while the expected output file already exist.
+  # The compression program should abort with an error
+  # (the printf is used to set STDIN to NULL, so gzip will not ask for confirmation)
+  printf "" | $comp -d $D/data.$ext 2>/dev/null \
+      && die "$comp - test 17 failed (brot did not warn about existing file)"
+  # Decompess again with force-overwrite
+  $comp -df $D/data.$ext || die "$comp - test 18 failed"
+
+  # Compress again
+  $comp -k $D/data || die "$comp - test 19 failed"
+  # Print with brotcat
+  $cat $D/data.$ext > $D/out4 || die "$comp - test 20 failed"
+  # compare output
+  cmp $D/data $D/out4 || die "$comp - test 21 failed"
+
+  # decompress with unbrot, overwrite existing output file
+  $decomp -f $D/data.$ext || die "$comp - test 22 failed"
+
+  # After decompression, original should exist, compressed file should not
+  test -e $D/data || die "$comp - test 23 failed"
+  test -e $D/data.$ext && die "$comp - test 24 failed"
+
+  # End of tests, delete temp dir
+  rm -r "$D"
+  echo "$comp - no tests failure"
+}
+
+# Run the same tests on each program.
+# we're not really testing gzip/bzip2/xz - just making sure they all behave
+# the same as 'brot'.
+runtests gzip  gunzip  zcat    gz
+runtests bzip2 bunzip2 bzcat   bz2
+runtests xz    unxz    xzcat   xz
+runtests brot  unbrot  brotcat bro

--- a/tools/brot.cc
+++ b/tools/brot.cc
@@ -1,0 +1,393 @@
+/* Copyright (C) 2015 Assaf Gordon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Compression/Decompression code copied from 'bro.cc':
+     Copyright 2014 Google Inc. All Rights Reserved.
+
+
+   a command-line version of 'brotli' compatible with the
+   common usage of gzip/bzip2/xz .
+*/
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <err.h>
+#include <string.h>
+#include <assert.h>
+#include <getopt.h>
+
+#include "../dec/decode.h"
+#include "../enc/encode.h"
+#include "../enc/streams.h"
+
+/* Program Version */
+#define VERSION "0.42"
+
+/* Email for Bug Reports */
+#define BUGREPORT "x@y.com"
+
+/* File extensions for brotli files */
+#define EXTENSION ".bro"
+#define EXTLEN    (strlen(EXTENSION))
+
+/* Program name meaning decompression (as with 'bunzip2') */
+#define DECOMP_PROGNAME "unbrot"
+
+/* Program name meaning decompression to STDOUT (as with 'bzcat') */
+#define CAT_PROGNAME "brotcat"
+
+enum _opmode {
+  COMPRESS,
+  DECOMPRESS
+} opmode = COMPRESS;
+
+static int compression_quality = 5; /* 1=fast, 9=best */
+static int force;
+static int quiet;
+static int to_stdout;
+static int keep_input;
+static int verbose;
+static const char* stdin_file_list[]={"-"};
+static const char** file_list;
+static int file_count;
+static char* progname;
+
+/* call malloc(), terminate on failure */
+void* xmalloc(size_t n)
+{
+  void *v = malloc(n);
+  if (!v)
+    err(1,"malloc failed");
+  return v;
+}
+
+/* call strdup(), terminate on failure */
+char* xstrdup(const char *s)
+{
+  char* c = strdup(s);
+  if (!c)
+    err(1,"strdup failed");
+  return c;
+}
+
+/* call strndup(), terminate on failure */
+char* xstrndup(const char *s, size_t l)
+{
+  char* c = strndup(s,l);
+  if (!c)
+    err(1,"strndup failed");
+  return c;
+}
+
+void show_license()
+{
+  printf("\
+Copyright (C) 2014-2015 XXXXX\n\
+\n\
+Licensed under the Apache License, Version 2.0 (the \"License\");\n\
+you may not use this file except in compliance with the License.\n\
+You may obtain a copy of the License at\n\
+\n\
+http://www.apache.org/licenses/LICENSE-2.0\n\
+\n");
+}
+
+void show_version()
+{
+  printf("brotli version " VERSION "\n");
+}
+
+void show_usage(const char* progname)
+{
+  show_version();
+
+  printf("\
+usage %s [flags] [input files...]\n\
+\n\
+  -c, --stdout      compress to stdout\n\
+  -d, --decompress  decompress\n\
+  -f, --force       force overwrite of output files, writing to terminal\n\
+  -k, --keep        keep original input files\n\
+  -L, --license     show license\n\
+  -q, --quiet       be quiet\n\
+  -v, --verbose     be verbose\n\
+  -V, --version     show version information\n\
+  -t, --test        test input archive\n\
+  -1, --fast        fastest compression\n\
+  -9, --best        best compression\n\
+\n\
+If no FILE or when FILE is -, read standard input.\n\
+\n\
+Report bugs to " BUGREPORT "\n", progname);
+}
+
+/* Prints a helpful message and exit with error code 1 */
+void exit_emit_try_help()
+{
+  errx(1,"Try '%s --help' for more information.",progname);
+}
+
+/* Parse command line options and input file names.
+   Sets global variable according to options.
+   Sets the 'file_list' and 'file_count' according to non-option parameters.
+   If no files given, sets 'file_list' to 'stdin_file_list'.  */
+void parse_command_line(int argc, char** argv)
+{
+  const char *progname = basename(argv[0]);
+
+  int ch;
+  static struct option longopts[] = {
+    {"best",      no_argument,   NULL,    '9'},
+    {"decompress",no_argument,   NULL,    'd'},
+    {"fast",      no_argument,   NULL,    '1'},
+    {"force",     no_argument,   NULL,    'f'},
+    {"help",      no_argument,   NULL,    'h'},
+    {"keep",      no_argument,   NULL,    'k'},
+    {"license",   no_argument,   NULL,    'L'},
+    {"quiet",     no_argument,   NULL,    'q'},
+    {"stdout",    no_argument,   NULL,    'c'},
+    {"test",      no_argument,   NULL,    't'},
+    {"verbose",   no_argument,   NULL,    'v'},
+    {"version",   no_argument,   NULL,    'V'},
+    {NULL,        0,             NULL,    0}
+  };
+
+  /* Change operation based on program name */
+  if (strcmp(progname,DECOMP_PROGNAME)==0)
+    opmode = DECOMPRESS;
+  if (strcmp(progname,CAT_PROGNAME)==0) {
+    to_stdout = 1;
+    opmode = DECOMPRESS;
+  }
+
+  while ((ch = getopt_long(argc, argv,
+                           "123456789cdfhkLqtvV", longopts, NULL)) != -1)
+    switch (ch) {
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        /* TODO: adapt quality to Brotli scale */
+        compression_quality = (ch - '9');
+        break;
+
+      case 'c':
+        opmode = COMPRESS;
+        to_stdout = 1;
+        break;
+
+      case 'd':
+        opmode = DECOMPRESS;
+        break;
+
+      case 'f':
+        force = 1;
+        break;
+
+      case 'h':
+        show_usage(argv[0]);
+        exit(0);
+
+      case 'k':
+        keep_input = 1;
+        break;
+
+      case 'L':
+        show_license();
+        exit(0);
+
+      case 'q':
+        quiet = 1;
+        break;
+
+      case 't':
+        errx(1,"-t/--test is not implemented");
+
+      case 'v':
+        verbose++;
+        break;
+
+      case 'V':
+        show_version();
+        exit(0);
+
+      case '?':
+      default:
+        exit_emit_try_help();
+    }
+  argc -= optind;
+  argv += optind;
+
+  if (argc==0) {
+    file_list = stdin_file_list;
+    file_count = 1;
+  } else {
+    file_list = (const char**)argv;
+    file_count = argc;
+  }
+}
+
+
+/* returns true (non-zero) if the filename represents STDIN */
+static int input_is_stdin(const char* infile)
+{
+  return (strcmp(infile,"-")==0);
+}
+
+/* Returns true (non-zero) if the output of this file
+   should go to STDOUT. */
+int output_to_stdout(const char* infile)
+{
+  return (to_stdout || input_is_stdin(infile));
+}
+
+/* returns a newly allocated, concatenated string of s1+s2.
+   string must be free'd.
+   terminates on error. */
+char* xstrconcat(const char* s1, const char* s2)
+{
+    const size_t l1 = strlen(s1);
+    const size_t l2 = strlen(s2);
+    char *out = (char*)xmalloc(l1+l2+1);
+    strcpy(out,s1);
+    strcat(out,s2);
+    return out;
+}
+
+/* Returns the output file name, based on the operation
+   (compess/decompress), the '-c' option, and the input file name. */
+char* get_output_filename(const char* infile)
+{
+  if (output_to_stdout(infile))
+    return xstrdup("(stdout)");
+
+  /* Compression to a file: add extension */
+  if (opmode==COMPRESS)
+    return xstrconcat(infile,EXTENSION);
+
+  /* Decompression to a file: remove extension (if found) */
+  const size_t len=strlen(infile);
+  if (len>EXTLEN && strcmp(&infile[len-EXTLEN],EXTENSION)==0)
+    return xstrndup(infile, len-EXTLEN);
+
+  /* Decompression, but can't detect extension, add ".out" */
+  char* outfile = xstrconcat(infile,".out");
+  if (!quiet)
+    warnx("Can't guess original name for %s -- using %s",infile,outfile);
+  return outfile;
+}
+
+FILE* open_input_file(const char* infile)
+{
+  if (input_is_stdin(infile))
+    return stdin;
+
+  FILE *f = fopen(infile,"rb");
+  if (f==NULL)
+    err(1,"failed to open '%s'", infile);
+  return f;
+}
+
+FILE* open_output_file(const char* infile, const char* outfile)
+{
+  if (output_to_stdout(infile))
+    return stdout;
+
+  if (!force) {
+    struct stat tmp;
+    if (stat(outfile, &tmp)==0)
+      errx(1,"output file '%s' already exists. Use -f to force overwrite",
+             outfile);
+  }
+
+  FILE *f = fopen(outfile, "wb");
+  if (f==NULL)
+    err(1,"failed to create/open '%s'", outfile);
+  return f;
+}
+
+void process_file(const char* infile)
+{
+  char *outfile = get_output_filename(infile);
+
+  FILE *fin = open_input_file(infile);
+  FILE *fout= open_output_file(infile, outfile);
+
+  if (verbose>0)
+    printf("%s '%s' to '%s'\n",
+         (opmode==COMPRESS)?"compressing":"decompressing",
+         infile, outfile);
+
+  if (opmode==COMPRESS) {
+    /* Compression */
+    brotli::BrotliParams params;
+    params.quality = compression_quality; //TODO: what's the scale here?
+    brotli::BrotliFileIn in(fin, 1 << 16);
+    brotli::BrotliFileOut out(fout);
+    if (!BrotliCompress(params, &in, &out)) {
+        warnx("compression failed");
+        unlink(outfile);
+        exit(1);
+    }
+  } else {
+    /* Decompression */
+    BrotliInput in = BrotliFileInput(fin);
+    BrotliOutput out = BrotliFileOutput(fout);
+    if (!BrotliDecompress(in, out))
+      errx(1,"decompression of '%s' failed (corrupted input?)", infile);
+  }
+
+  if (fclose(fin))
+    err(1,"closing '%s' failed", infile);
+  if (fclose(fout))
+    err(1,"closing '%s' failed", outfile);
+
+  if (!keep_input && !input_is_stdin(infile) && !output_to_stdout(infile)) {
+    if (unlink(infile) != 0)
+      err(1,"removing input file '%s' failed", infile);
+  }
+
+  free (outfile);
+}
+
+int main(int argc, char** argv)
+{
+  progname = argv[0];
+  parse_command_line(argc, argv);
+
+  for (int i=0; i<file_count; ++i) {
+    const char* infile = file_list[i];
+
+    if (opmode==COMPRESS && output_to_stdout(infile)
+        && isatty(fileno(stdout)) && !force) {
+      warnx("Compressed data can't be written to terminal. " \
+            "Use -f to force compression.");
+      exit_emit_try_help();
+    }
+
+    process_file (infile);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
'brot' supports the same common usage as gzip/bzip2/xz .

add two test scripts:
* brot-test.sh compares behaviour with gzip/bzip2/xz
* brot-size-test.sh compares compression sizes with gzip/bzip2/xz

(could be renamed to 'bro', but I didn't want to override the current 'bro' program).