### PR TITLE
replace vector.data() with &vector[0] for MSVC90 compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
-      WINDOWS_SDK_VERSION: "v7.1"
+      WINDOWS_SDK_VERSION: "v7.0"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -191,7 +191,7 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args) {
 
   ok = BrotliDecompress(in, out);
   if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)output.data(), output.size());
+    ret = PyBytes_FromStringAndSize((char*)(output.size() ? &output[0] : NULL), output.size());
   } else {
     PyErr_SetString(BrotliError, "BrotliDecompress failed");
   }

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+try:
+    import setuptools
+except:
+    pass
 import distutils
 from distutils.core import setup, Extension
 from distutils.command.build_ext import build_ext
@@ -8,19 +12,6 @@ import re
 
 
 CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-# when compiling for Windows Python 2.7, force distutils to use Visual Studio
-# 2010 instead of 2008, as the latter doesn't support c++0x
-if platform.system() == 'Windows':
-    try:
-        import distutils.msvc9compiler
-    except distutils.errors.DistutilsPlatformError:
-        pass  # importing msvc9compiler raises when running under MinGW
-    else:
-        orig_find_vcvarsall = distutils.msvc9compiler.find_vcvarsall
-        def patched_find_vcvarsall(version):
-            return orig_find_vcvarsall(version if version != 9.0 else 10.0)
-        distutils.msvc9compiler.find_vcvarsall = patched_find_vcvarsall
 
 
 def get_version():


### PR DESCRIPTION
This patch is meant to address issue #200, by replacing all uses of `vector.data()` with `&vector[0]`.

I also removed the distutils patch inside setup.py, so that the correct MSVC compiler version is selected automatically based on the python version (9.0 for Py2.7, 10.0 for Python 3.4, etc.) 

The `import setuptools` at the beginning of setup.py is required to use the "MS Visual C++ for Python 2.7" (http://aka.ms/vcpython27). Unfortunately the stock distutils fails to locate the `vcvarsall.bat` file..
This issue is fixed in setuptools (which is now bundled along with pip with the latest Python.org installers, and is the recommended way to distribute Python packages).

I know it looks terrible -- but at least shows how with little change we can make it work even with MSVC 9.0 and Windows Python 2.7.

Let me know what you think.
Thanks




