### PR TITLE
[types.h] make std integer types for _MSC_VER compatible with CFFI

### DIFF
--- a/dec/types.h
+++ b/dec/types.h
@@ -21,14 +21,14 @@
 #include <stddef.h>  /* for size_t */
 
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
-typedef signed   char int8_t;
-typedef unsigned char uint8_t;
-typedef signed   short int16_t;
-typedef unsigned short uint16_t;
-typedef signed   int int32_t;
-typedef unsigned int uint32_t;
-typedef unsigned long long int uint64_t;
-typedef long long int int64_t;
+typedef __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+typedef __int64 int64_t;
 #else
 #include <stdint.h>
 #endif  /* defined(_MSC_VER) && (_MSC_VER < 1600) */

--- a/enc/types.h
+++ b/enc/types.h
@@ -21,14 +21,14 @@
 #include <stddef.h>  /* for size_t */
 
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
-typedef signed   char int8_t;
-typedef unsigned char uint8_t;
-typedef signed   short int16_t;
-typedef unsigned short uint16_t;
-typedef signed   int int32_t;
-typedef unsigned int uint32_t;
-typedef unsigned long long int uint64_t;
-typedef long long int int64_t;
+typedef __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+typedef __int64 int64_t;
 #else
 #include <stdint.h>
 #endif  /* defined(_MSC_VER) && (_MSC_VER < 1600) */


### PR DESCRIPTION
[CFFI](https://cffi.readthedocs.org/en/latest/index.html) (C Foreign Function Interface for Python) provides an alternative, easier way to call compiled C/C++ code from Python, than using CPython API (like in the current `brotlimodule.cc`).

I am trying to use CFFI to build Brotli's Python bindings.

Everything works fine, except for another issue related, once again, to MS VC++ 9.0.

As you know, the latter doesn't have `stdint.h`, so both CFFI and Brotli have to explicitly define the standard integer types when `_MSC_VER < 1600`.

The problem is the `_cffi_inculde.h` [header file](https://bitbucket.org/cffi/cffi/src/21fef94ca0c88a16b007fb495806d0371b7f878d/cffi/_cffi_include.h?at=default&fileviewer=file-view-default#_cffi_include.h-15) contains slightly different definitions than the ones inlcuded in Brotli's own `enc/types.h` and `dec/types.h`

This makes Microsoft Visual C++ 9.0 compiler complain with the following error:

```
enc\types.h(24) : error C2371: 'int8_t' : redefinition; different basic types
        build\temp.win32-2.7\Release\_brotli_cffi.cpp(179) : see declaration of 'int8_t'
```

Now, if in `enc/types.h` and `dec/types.h` I reuse the same definitions as `_cffi_include.h`, then MSVC90 is happy and my CFFI extension module can be compiled succesfully.