### PR TITLE
Encoder fixes.

### DIFF
--- a/enc/brotli_bit_stream.cc
+++ b/enc/brotli_bit_stream.cc
@@ -339,6 +339,7 @@ std::vector<int> MoveToFrontTransform(const std::vector<int>& v) {
   std::vector<int> result(v.size());
   for (int i = 0; i < v.size(); ++i) {
     int index = IndexOf(mtf, v[i]);
+    assert(index >= 0);
     result[i] = index;
     MoveToFront(&mtf, index);
   }

--- a/enc/command.h
+++ b/enc/command.h
@@ -90,8 +90,6 @@ static inline void GetLengthCode(int insertlen, int copylen, int distancecode,
 }
 
 struct Command {
-  Command() {}
-
   // distance_code is e.g. 0 for same-as-last short code, or 16 for offset 1.
   Command(int insertlen, int copylen, int copylen_code, int distance_code)
       : insert_len_(insertlen), copy_len_(copylen) {

--- a/enc/entropy_encode.cc
+++ b/enc/entropy_encode.cc
@@ -29,7 +29,6 @@ namespace brotli {
 namespace {
 
 struct HuffmanTree {
-  HuffmanTree();
   HuffmanTree(int count, int16_t left, int16_t right)
       : total_count_(count),
         index_left_(left),
@@ -39,8 +38,6 @@ struct HuffmanTree {
   int16_t index_left_;
   int16_t index_right_or_value_;
 };
-
-HuffmanTree::HuffmanTree() {}
 
 // Sort the root nodes, least popular first.
 bool SortHuffmanTree(const HuffmanTree &v0, const HuffmanTree &v1) {

--- a/enc/histogram.h
+++ b/enc/histogram.h
@@ -18,6 +18,7 @@
 #define BROTLI_ENC_HISTOGRAM_H_
 
 #include <string.h>
+#include <limits>
 #include <vector>
 #include <utility>
 #include "./command.h"
@@ -38,6 +39,7 @@ struct Histogram {
   void Clear() {
     memset(data_, 0, sizeof(data_));
     total_count_ = 0;
+    bit_cost_ = std::numeric_limits<double>::infinity();
   }
   void Add(int val) {
     ++data_[val];

--- a/enc/streams.cc
+++ b/enc/streams.cc
@@ -89,18 +89,14 @@ const void* BrotliMemIn::Read(size_t n, size_t* output) {
 
 BrotliFileIn::BrotliFileIn(FILE* f, size_t max_read_size)
     : f_(f),
-      buf_(malloc(max_read_size)),
-      buf_size_(max_read_size) {}
+      buf_(new char[max_read_size]),
+      buf_size_(max_read_size) { }
 
 BrotliFileIn::~BrotliFileIn() {
-  if (buf_) free(buf_);
+  delete[] buf_;
 }
 
 const void* BrotliFileIn::Read(size_t n, size_t* bytes_read) {
-  if (buf_ == NULL) {
-    *bytes_read = 0;
-    return NULL;
-  }
   if (n > buf_size_) {
     n = buf_size_;
   } else if (n == 0) {

--- a/enc/streams.h
+++ b/enc/streams.h
@@ -110,7 +110,7 @@ class BrotliFileIn : public BrotliIn {
 
  private:
   FILE* f_;
-  void* buf_;
+  char* buf_;
   size_t buf_size_;
 };
 


### PR DESCRIPTION
* Remove default constructors.
* Initialize bit_cost in histogram.Clear().
* Check fseek result in FileSize.
* Replace malloc in BrotliFileIn constructor with "new".
* Catch bad_alloc in bro tool.