### PR TITLE
Fix the introduction part of the specification.

### DIFF
--- a/docs/draft-alakuijala-brotli-06.nroff
+++ b/docs/draft-alakuijala-brotli-06.nroff
@@ -226,7 +226,7 @@ relative LSB position).
 2. Compressed representation overview
 
 A compressed data set consists of a header and a series of meta-
-blocks. Each meta-block decompresses to a sequence of 1
+blocks. Each meta-block decompresses to a sequence of 0
 to 16,777,216 (16 MiB) uncompressed bytes. The final uncompressed data is
 the concatenation of the uncompressed sequences from each meta-block.
 
@@ -234,8 +234,8 @@ The header contains the size of the sliding window that was used during compress
 The decompressor must retain at least that amount of uncompressed data prior to the
 current position in the stream, in order to be able to decompress
 what follows. The sliding window size is a power of two, minus 16, where
-the power is in the range of 16 to 24. The possible sliding window
-sizes range from 64 KiB - 16 B to 16 MiB - 16 B.
+the power is in the range of 10 to 24. The possible sliding window
+sizes range from 1 KiB - 16 B to 16 MiB - 16 B.
 
 Each meta-block is compressed using a combination of the LZ77
 algorithm (Lempel-Ziv 1977, [LZ77]) and Huffman coding. The

--- a/docs/draft-alakuijala-brotli-06.txt
+++ b/docs/draft-alakuijala-brotli-06.txt
@@ -255,7 +255,7 @@ Internet-Draft                   Brotli                     October 2015
 2. Compressed representation overview
 
    A compressed data set consists of a header and a series of meta-
-   blocks. Each meta-block decompresses to a sequence of 1 to 16,777,216
+   blocks. Each meta-block decompresses to a sequence of 0 to 16,777,216
    (16 MiB) uncompressed bytes. The final uncompressed data is the
    concatenation of the uncompressed sequences from each meta-block.
 
@@ -264,8 +264,8 @@ Internet-Draft                   Brotli                     October 2015
    amount of uncompressed data prior to the current position in the
    stream, in order to be able to decompress what follows. The sliding
    window size is a power of two, minus 16, where the power is in the
-   range of 16 to 24. The possible sliding window sizes range from 64
-   KiB - 16 B to 16 MiB - 16 B.
+   range of 10 to 24. The possible sliding window sizes range from 1 KiB
+   - 16 B to 16 MiB - 16 B.
 
    Each meta-block is compressed using a combination of the LZ77
    algorithm (Lempel-Ziv 1977, [LZ77]) and Huffman coding. The result of


### PR DESCRIPTION
- window bits can be 10 to 24
- meta block can have 0 length