### PR TITLE
Added note about invalid distance values

### DIFF
--- a/docs/draft-alakuijala-brotli-07.nroff
+++ b/docs/draft-alakuijala-brotli-07.nroff
@@ -865,6 +865,9 @@ Given a distance symbol "dcode" (>= 16 + NDIRECT), and extra bits
    distance = ((offset + dextra) << NPOSTFIX) + lcode + NDIRECT + 1
 .fi
 
+If a decoded distance has a zero or negative value, the stream should
+be rejected as invalid.
+
 .ti 0
 5. Encoding of literal insertion lengths and copy lengths
 

--- a/docs/draft-alakuijala-brotli-07.nroff
+++ b/docs/draft-alakuijala-brotli-07.nroff
@@ -842,6 +842,9 @@ distance that was not represented by a 0 distance symbol. Similarly,
 distances that represent static dictionary words (see Section 8.) are
 not pushed to the ring buffer of last distances.
 
+If a special distance symbol resolves to a zero or negative value, the
+stream should be rejected as invalid.
+
 The next NDIRECT distance symbols, from 16 to 15 + NDIRECT, represent
 distances from 1 to NDIRECT. Neither the distance special symbols, nor
 the NDIRECT direct distance symbols are followed by any extra bits.
@@ -864,9 +867,6 @@ Given a distance symbol "dcode" (>= 16 + NDIRECT), and extra bits
    offset = ((2 + (hcode & 1)) << ndistbits) - 4;
    distance = ((offset + dextra) << NPOSTFIX) + lcode + NDIRECT + 1
 .fi
-
-If a decoded distance has a zero or negative value, the stream should
-be rejected as invalid.
 
 .ti 0
 5. Encoding of literal insertion lengths and copy lengths

--- a/docs/draft-alakuijala-brotli-07.txt
+++ b/docs/draft-alakuijala-brotli-07.txt
@@ -77,7 +77,7 @@ Table of Contents
       3.4.  Simple prefix codes . . . . . . . . . . . . . . . . . . . 12
       3.5.  Complex prefix codes  . . . . . . . . . . . . . . . . . . 13
    4.  Encoding of distances  . . . . . . . . . . . . . . . . . . . . 16
-   5.  Encoding of literal insertion lengths and copy lengths . . . . 17
+   5.  Encoding of literal insertion lengths and copy lengths . . . . 18
    6.  Encoding of block switch commands  . . . . . . . . . . . . . . 20
    7.  Context modeling . . . . . . . . . . . . . . . . . . . . . . . 21
       7.1.  Context modes and context ID lookup for literals  . . . . 21
@@ -947,7 +947,7 @@ Internet-Draft                   Brotli                     October 2015
       offset = ((2 + (hcode & 1)) << ndistbits) - 4;
       distance = ((offset + dextra) << NPOSTFIX) + lcode + NDIRECT + 1
 
-5. Encoding of literal insertion lengths and copy lengths
+   If a decoded distance has a zero or negative value, the stream should
 
 
 
@@ -955,6 +955,10 @@ Alakuijala & Szabadka     Expires April 6, 2016                [Page 17]
 
 Internet-Draft                   Brotli                     October 2015
 
+
+   be rejected as invalid.
+
+5. Encoding of literal insertion lengths and copy lengths
 
    As described in Section 2, the literal insertion lengths and backward
    copy lengths are encoded using a single prefix code. This section
@@ -998,10 +1002,6 @@ Internet-Draft                   Brotli                     October 2015
 
    The symbols of the copy length code alphabet, along with the number
    of copy extra bits and the range of copy lengths are as follows:
-
-
-
-
 
 
 

--- a/docs/draft-alakuijala-brotli-07.txt
+++ b/docs/draft-alakuijala-brotli-07.txt
@@ -925,6 +925,9 @@ Internet-Draft                   Brotli                     October 2015
    symbol. Similarly, distances that represent static dictionary words
    (see Section 8.) are not pushed to the ring buffer of last distances.
 
+   If a special distance symbol resolves to a zero or negative value,
+   the stream should be rejected as invalid.
+
    The next NDIRECT distance symbols, from 16 to 15 + NDIRECT, represent
    distances from 1 to NDIRECT. Neither the distance special symbols,
    nor the NDIRECT direct distance symbols are followed by any extra
@@ -945,9 +948,6 @@ Internet-Draft                   Brotli                     October 2015
       hcode = (dcode - NDIRECT - 16) >> NPOSTFIX
       lcode = (dcode - NDIRECT - 16) & POSTFIX_MASK
       offset = ((2 + (hcode & 1)) << ndistbits) - 4;
-      distance = ((offset + dextra) << NPOSTFIX) + lcode + NDIRECT + 1
-
-   If a decoded distance has a zero or negative value, the stream should
 
 
 
@@ -956,7 +956,7 @@ Alakuijala & Szabadka     Expires April 6, 2016                [Page 17]
 Internet-Draft                   Brotli                     October 2015
 
 
-   be rejected as invalid.
+      distance = ((offset + dextra) << NPOSTFIX) + lcode + NDIRECT + 1
 
 5. Encoding of literal insertion lengths and copy lengths
 


### PR DESCRIPTION
It might be helpful for implementers to mention briefly conditions that qualify an input stream for rejection. This has already been applied in other places, so I believe it would make sense for distances as well.

It is my understanding that a negative distance, or a zero distance should be rejected as invalid.