### PR TITLE
FIX: Typo in reference to NBLTYPESL, Minor: added missing word _lengths_ to insert-and-copy lengths

### DIFF
--- a/docs/draft-alakuijala-brotli-07.nroff
+++ b/docs/draft-alakuijala-brotli-07.nroff
@@ -1741,9 +1741,9 @@ The decoding algorithm that produces the uncompressed data is as follows:
          read distance context map, CMAPD[]
       else
          fill CMAPD[] with zeros
-      read array of prefix codes for literals, HTREEL[]
-      read array of prefix codes for insert-and-copy lengths, HTREEI[]
-      read array of prefix codes for distances, HTREED[]
+      read array of literals prefix codes, HTREEL[]
+      read array of insert-and-copy lengths prefix codes, HTREEI[]
+      read array of distances prefix codes, HTREED[]
       do
          if BLEN_I is zero
             read block type using HTREE_BTYPE_I and set BTYPE_I

--- a/docs/draft-alakuijala-brotli-07.nroff
+++ b/docs/draft-alakuijala-brotli-07.nroff
@@ -1741,9 +1741,9 @@ The decoding algorithm that produces the uncompressed data is as follows:
          read distance context map, CMAPD[]
       else
          fill CMAPD[] with zeros
-      read array of literals prefix codes, HTREEL[]
-      read array of insert-and-copy lengths prefix codes, HTREEI[]
-      read array of distances prefix codes, HTREED[]
+      read array of literal prefix codes, HTREEL[]
+      read array of insert-and-copy length prefix codes, HTREEI[]
+      read array of distance prefix codes, HTREED[]
       do
          if BLEN_I is zero
             read block type using HTREE_BTYPE_I and set BTYPE_I

--- a/docs/draft-alakuijala-brotli-07.nroff
+++ b/docs/draft-alakuijala-brotli-07.nroff
@@ -1742,7 +1742,7 @@ The decoding algorithm that produces the uncompressed data is as follows:
       else
          fill CMAPD[] with zeros
       read array of prefix codes for literals, HTREEL[]
-      read array of prefix codes for insert-and-copy, HTREEI[]
+      read array of prefix codes for insert-and-copy lengths, HTREEI[]
       read array of prefix codes for distances, HTREED[]
       do
          if BLEN_I is zero

--- a/docs/draft-alakuijala-brotli-07.nroff
+++ b/docs/draft-alakuijala-brotli-07.nroff
@@ -1646,11 +1646,11 @@ commands. Each command has the following format:
       Insert length number of literals, with the following format:
 
          Block type code for next literal block type, appears
-            only if NBLTYPESI >= 2 and the previous literal
+            only if NBLTYPESL >= 2 and the previous literal
             block count is zero
 
          Block count code + extra bits for next literal
-            block count, appears only if NBLTYPESI >= 2 and the
+            block count, appears only if NBLTYPESL >= 2 and the
             previous literal block count is zero
 
          Next byte of the uncompressed data, encoded with the

--- a/docs/draft-alakuijala-brotli-07.txt
+++ b/docs/draft-alakuijala-brotli-07.txt
@@ -1746,11 +1746,11 @@ Internet-Draft                   Brotli                     October 2015
          Insert length number of literals, with the following format:
 
             Block type code for next literal block type, appears
-               only if NBLTYPESI >= 2 and the previous literal
+               only if NBLTYPESL >= 2 and the previous literal
                block count is zero
 
             Block count code + extra bits for next literal
-               block count, appears only if NBLTYPESI >= 2 and the
+               block count, appears only if NBLTYPESL >= 2 and the
                previous literal block count is zero
 
             Next byte of the uncompressed data, encoded with the

--- a/docs/draft-alakuijala-brotli-07.txt
+++ b/docs/draft-alakuijala-brotli-07.txt
@@ -1854,9 +1854,9 @@ Internet-Draft                   Brotli                     October 2015
 
          else
             fill CMAPD[] with zeros
-         read array of literals prefix codes, HTREEL[]
-         read array of insert-and-copy lengths prefix codes, HTREEI[]
-         read array of distances prefix codes, HTREED[]
+         read array of literal prefix codes, HTREEL[]
+         read array of insert-and-copy length prefix codes, HTREEI[]
+         read array of distance prefix codes, HTREED[]
          do
             if BLEN_I is zero
                read block type using HTREE_BTYPE_I and set BTYPE_I

--- a/docs/draft-alakuijala-brotli-07.txt
+++ b/docs/draft-alakuijala-brotli-07.txt
@@ -1855,7 +1855,7 @@ Internet-Draft                   Brotli                     October 2015
          else
             fill CMAPD[] with zeros
          read array of prefix codes for literals, HTREEL[]
-         read array of prefix codes for insert-and-copy, HTREEI[]
+         read array of prefix codes for insert-and-copy lengths, HTREEI[]
          read array of prefix codes for distances, HTREED[]
          do
             if BLEN_I is zero

--- a/docs/draft-alakuijala-brotli-07.txt
+++ b/docs/draft-alakuijala-brotli-07.txt
@@ -1854,9 +1854,9 @@ Internet-Draft                   Brotli                     October 2015
 
          else
             fill CMAPD[] with zeros
-         read array of prefix codes for literals, HTREEL[]
-         read array of prefix codes for insert-and-copy lengths, HTREEI[]
-         read array of prefix codes for distances, HTREED[]
+         read array of literals prefix codes, HTREEL[]
+         read array of insert-and-copy lengths prefix codes, HTREEI[]
+         read array of distances prefix codes, HTREED[]
          do
             if BLEN_I is zero
                read block type using HTREE_BTYPE_I and set BTYPE_I


### PR DESCRIPTION
Looks like the word "lengths" was missing.
Note: the line is now 73 characters long. There are a couple of lines as long as that one. It might have been a deliberate choice to omit the word to keep the line short.
If so, please reject.