### PR TITLE
Fixed issue when linking with C++/CLI application

### DIFF
--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -629,7 +629,7 @@ int BrotliCompressWithCustomDictionary(size_t dictsize, const uint8_t* dict,
                                        BrotliIn* in, BrotliOut* out) {
   size_t in_bytes = 0;
   size_t out_bytes = 0;
-  uint8_t* output;
+  uint8_t* output = NULL;
   bool final_block = false;
   BrotliCompressor compressor(params);
   if (dictsize != 0) compressor.BrotliSetCustomDictionary(dictsize, dict);


### PR DESCRIPTION
The Microsoft Visual C++ compiler, or specifically linker, generates an error about a possible uninitialized pointer when linking with a C++/CLI application if `output` is left uninitialized. This fixes that issue.

I get that this is a really minor thing but at least this way no one else needs to run into this issue if they want to use brotli in a C++/CLI project.

