### PR TITLE
Avoid integer overflow on x86_64-mingw, closes #264

### DIFF
--- a/enc/write_bits.h
+++ b/enc/write_bits.h
@@ -49,7 +49,7 @@ inline void WriteBits(int n_bits,
 #ifdef BIT_WRITER_DEBUG
   printf("WriteBits  %2d  0x%016llx  %10d\n", n_bits, bits, *pos);
 #endif
-  assert(bits < 1UL << n_bits);
+  assert(bits < 1ULL << n_bits);
 #ifdef IS_LITTLE_ENDIAN
   // This branch of the code can write up to 56 bits at a time,
   // 7 bits are lost by being perhaps already in *p and at least


### PR DESCRIPTION
Cf. #264 for an explanation of the actual problem.

I don't really have a good Visual Studio to test if that changes makes VC emit a warning - but at the very least I expect it to keep producing valid code.

In the future, would you consider adding mingw32 tests to your AppVeyor config? It's non-trivial, but doable. (Although, it would've have caught that particular issue, none of the test files triggered it at the tested qualities, or even at q=4).