### PR TITLE
don't pass `-std=c++0x` option to gcc in setup.py

### DIFF
--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -21,9 +21,9 @@ static int mode_convertor(PyObject *o, BrotliParams::Mode *mode) {
   }
 
   *mode = (BrotliParams::Mode) PyInt_AsLong(o);
-  if (*mode != BrotliParams::Mode::MODE_GENERIC &&
-      *mode != BrotliParams::Mode::MODE_TEXT &&
-      *mode != BrotliParams::Mode::MODE_FONT) {
+  if (*mode != BrotliParams::MODE_GENERIC &&
+      *mode != BrotliParams::MODE_TEXT &&
+      *mode != BrotliParams::MODE_FONT) {
     PyErr_SetString(BrotliError, "Invalid mode");
     return 0;
   }
@@ -240,9 +240,9 @@ PyMODINIT_FUNC INIT_BROTLI(void) {
     PyModule_AddObject(m, "error", BrotliError);
   }
 
-  PyModule_AddIntConstant(m, "MODE_GENERIC", (int) BrotliParams::Mode::MODE_GENERIC);
-  PyModule_AddIntConstant(m, "MODE_TEXT", (int) BrotliParams::Mode::MODE_TEXT);
-  PyModule_AddIntConstant(m, "MODE_FONT", (int) BrotliParams::Mode::MODE_FONT);
+  PyModule_AddIntConstant(m, "MODE_GENERIC", (int) BrotliParams::MODE_GENERIC);
+  PyModule_AddIntConstant(m, "MODE_TEXT", (int) BrotliParams::MODE_TEXT);
+  PyModule_AddIntConstant(m, "MODE_FONT", (int) BrotliParams::MODE_FONT);
 
   PyModule_AddStringConstant(m, "__version__", BROTLI_VERSION);
 

--- a/setup.py
+++ b/setup.py
@@ -70,12 +70,8 @@ class BuildExt(build_ext):
 
         objects = []
         for lang, sources in (("c", c_sources), ("c++", cxx_sources)):
-            if lang == "c++": 
-                if platform.system() == "Darwin":
-                    extra_args.extend(["-stdlib=libc++", "-mmacosx-version-min=10.7"])
-                if self.compiler.compiler_type in ["unix", "cygwin", "mingw32"]:
-                    extra_args.append("-std=c++0x")
-                elif self.compiler.compiler_type == "msvc":
+            if lang == "c++":
+                if self.compiler.compiler_type == "msvc":
                     extra_args.append("/EHsc")
 
             macros = ext.define_macros[:]


### PR DESCRIPTION
Now that Brotli can be built with older compilers that don't support C++11, I think it's fine to turn that off in the `setup.py` script which compiles the Python extension module.