### PR TITLE
Fix typo: LFLAGS => LDFLAGS

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -13,7 +13,7 @@ EXE_OBJS=$(patsubst %, %.o, $(EXECUTABLES))
 all : $(EXECUTABLES)
 
 $(EXECUTABLES) : $(EXE_OBJS) deps
-	$(CXX) $(LFLAGS) $(ENCOBJ) $(DECOBJ) $@.o -o $@
+	$(CXX) $(LDFLAGS) $(ENCOBJ) $(DECOBJ) $@.o -o $@
 
 deps :
 	$(MAKE) -C $(BROTLI)/dec


### PR DESCRIPTION
Hi,
I found this minor typo in tools/Makefile.

Cheers,
Tomasz