### PR TITLE
Remove -std=c++11 from shared.mk

### DIFF
--- a/shared.mk
+++ b/shared.mk
@@ -10,4 +10,4 @@ ifeq ($(OS), Darwin)
 endif
 
 CFLAGS += $(COMMON_FLAGS)
-CXXFLAGS += $(COMMON_FLAGS) -std=c++11
+CXXFLAGS += $(COMMON_FLAGS)


### PR DESCRIPTION
#278 removed -std=c++0x when compiling with setup.py. We don't appear to actually need c++11 for brotli in general so remove it from shared.mk.