### PR TITLE
Reorder members of the Command struct plus fix some warnings.

### DIFF
--- a/enc/brotli_bit_stream.cc
+++ b/enc/brotli_bit_stream.cc
@@ -655,8 +655,8 @@ void StoreTrivialContextMap(size_t num_types,
                             uint8_t* storage) {
   StoreVarLenUint8(num_types - 1, storage_ix, storage);
   if (num_types > 1) {
-    size_t repeat_code = context_bits - 1;
-    uint64_t repeat_bits = (1 << repeat_code) - 1;
+    size_t repeat_code = context_bits - 1u;
+    size_t repeat_bits = (1u << repeat_code) - 1u;
     size_t alphabet_size = num_types + repeat_code;
     std::vector<uint32_t> histogram(alphabet_size);
     std::vector<uint8_t> depths(alphabet_size);

--- a/enc/command.h
+++ b/enc/command.h
@@ -100,7 +100,7 @@ struct Command {
 
   explicit Command(size_t insertlen)
       : insert_len_(static_cast<uint32_t>(insertlen))
-      , copy_len_(0), dist_prefix_(16), dist_extra_(0) {
+      , copy_len_(0), dist_extra_(0), dist_prefix_(16) {
     GetLengthCode(insertlen, 4, dist_prefix_ == 0, &cmd_prefix_, &cmd_extra_);
   }
 
@@ -125,10 +125,10 @@ struct Command {
 
   uint32_t insert_len_;
   uint32_t copy_len_;
-  uint16_t cmd_prefix_;
-  uint16_t dist_prefix_;
   uint64_t cmd_extra_;
   uint32_t dist_extra_;
+  uint16_t cmd_prefix_;
+  uint16_t dist_prefix_;
 };
 
 }  // namespace brotli

--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -193,6 +193,7 @@ BrotliCompressor::BrotliCompressor(BrotliParams params)
       storage_size_(0),
       storage_(0),
       large_table_(NULL),
+      cmd_code_numbits_(0),
       command_buf_(NULL),
       literal_buf_(NULL) {
   // Sanitize params.


### PR DESCRIPTION
This may save 8 bytes of padding per Command (32 -> 24 bytes).