### PR TITLE
Make stdin/stdout work on Windows for tools/bro

### DIFF
--- a/tools/bro.cc
+++ b/tools/bro.cc
@@ -131,7 +131,8 @@ error:
 
 static FILE* OpenInputFile(const char* input_path) {
   if (input_path == 0) {
-    return fdopen(STDIN_FILENO, "rb");
+    setmode(_fileno(stdin), O_BINARY);
+    return stdin;
   }
   FILE* f = fopen(input_path, "rb");
   if (f == 0) {
@@ -143,7 +144,8 @@ static FILE* OpenInputFile(const char* input_path) {
 
 static FILE *OpenOutputFile(const char *output_path, const int force) {
   if (output_path == 0) {
-    return fdopen(STDOUT_FILENO, "wb");
+    setmode(_fileno(stdout), O_BINARY);
+    return stdout;
   }
   int excl = force ? 0 : O_EXCL;
   int fd = open(output_path, O_CREAT | excl | O_WRONLY | O_TRUNC,

--- a/tools/bro.cc
+++ b/tools/bro.cc
@@ -18,6 +18,13 @@
 #include "../dec/decode.h"
 #include "../enc/encode.h"
 
+#ifdef _WIN32
+# include <io.h>
+# include <fcntl.h>
+# define SET_BINARY_MODE(handle) setmode((handle), O_BINARY)
+#else
+# define SET_BINARY_MODE(handle) ((void)0)
+#endif
 
 static bool ParseQuality(const char* s, int* quality) {
   if (s[0] >= '0' && s[0] <= '9') {
@@ -131,7 +138,7 @@ error:
 
 static FILE* OpenInputFile(const char* input_path) {
   if (input_path == 0) {
-    setmode(_fileno(stdin), O_BINARY);
+    SET_BINARY_MODE(stdin);
     return stdin;
   }
   FILE* f = fopen(input_path, "rb");
@@ -144,7 +151,7 @@ static FILE* OpenInputFile(const char* input_path) {
 
 static FILE *OpenOutputFile(const char *output_path, const int force) {
   if (output_path == 0) {
-    setmode(_fileno(stdout), O_BINARY);
+    SET_BINARY_MODE(stdout);
     return stdout;
   }
   int excl = force ? 0 : O_EXCL;


### PR DESCRIPTION
The code in master works well on Linux/OSX, not so well on Windows. This PR makes it work for all 3 main platforms. Props to #174 for giving helpful hints!

Tested on OSX 10.11.3 with clang 7.0.2, and Windows 10 with msys2, gcc 5.2.0