### PR TITLE
build: create an encoder and decoder library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,89 @@
+AUTOMAKE_OPTIONS = foreign nostdinc subdir-objects
+
+ACLOCAL_AMFLAGS = -I m4
+
+lib_LTLIBRARIES = libbrotlidec.la libbrotlienc.la
+
+DECODE = dec/bit_reader.c dec/decode.c dec/huffman.c dec/state.c	\
+  dec/dictionary.c
+
+ENCODE = enc/backward_references.cc enc/histogram.cc			\
+ enc/block_splitter.cc enc/literal_cost.cc enc/brotli_bit_stream.cc	\
+ enc/metablock.cc enc/encode.cc enc/static_dict.cc			\
+ enc/encode_parallel.cc enc/streams.cc enc/entropy_encode.cc		\
+ enc/dictionary.cc enc/utf8_util.cc enc/compress_fragment.cc		\
+ enc/compress_fragment_two_pass.cc
+
+DECODEHEADERS = dec/decode.h dec/state.h dec/types.h dec/bit_reader.h	\
+ dec/huffman.h dec/port.h dec/context.h dec/dictionary.h		\
+ dec/transform.h dec/prefix.h
+
+ENCODEHEADERS = enc/encode.h enc/command.h enc/hash.h enc/ringbuffer.h	\
+ enc/static_dict.h enc/streams.h enc/fast_log.h enc/prefix.h		\
+ enc/dictionary_hash.h enc/find_match_length.h enc/port.h		\
+ enc/transform.h enc/dictionary.h enc/backward_references.h		\
+ enc/histogram.h enc/block_splitter.h enc/metablock.h enc/context.h	\
+ enc/literal_cost.h enc/cluster.h enc/bit_cost.h enc/entropy_encode.h	\
+ enc/brotli_bit_stream.h enc/write_bits.h enc/static_dict_lut.h		\
+ enc/encode_parallel.h enc/types.h enc/utf8_util.h			\
+ enc/compress_fragment.h enc/compress_fragment_two_pass.h		\
+ enc/entropy_encode_static.h
+
+EXTRA_DIST = CONTRIBUTING.md README.md
+
+# install headers in $(includedir) with subdirs
+nobase_include_HEADERS = $(DECODEHEADERS) $(ENCODEHEADERS)
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libbrotlienc.pc libbrotlidec.pc
+pkgincludedir= $(includedir)/brotli
+pkginclude_HEADERS = 
+
+LIBBROTLIENC_VERSION_INFO = -version-info 1:0:0
+LIBBROTLIDEC_VERSION_INFO = -version-info 1:0:0
+# This flag accepts an argument of the form current[:revision[:age]]. So,
+# passing -version-info 3:12:1 sets current to 3, revision to 12, and age to
+# 1.
+#
+# If either revision or age are omitted, they default to 0. Also note that age
+# must be less than or equal to the current interface number.
+#
+# Here are a set of rules to help you update your library version information: 
+#
+# 1.Start with version information of 0:0:0 for each libtool library.
+#
+# 2.Update the version information only immediately before a public release of
+# your software. More frequent updates are unnecessary, and only guarantee
+# that the current interface number gets larger faster.
+#
+# 3.If the library source code has changed at all since the last update, then
+# increment revision (c:r+1:a)
+#
+# 4.If any interfaces have been added, removed, or changed since the last
+# update, increment current, and set revision to 0. (c+1:r=0:a)
+#
+# 5.If any interfaces have been added since the last public release, then
+# increment age. (c:r:a+1)
+#
+# 6.If any interfaces have been removed since the last public release, then
+# set age to 0. (c:r:a=0)
+#
+
+libbrotlidec_la_CPPFLAGS_EXTRA = -DBROTLI_BUILDING_LIBRARY
+libbrotlidec_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLIDEC_VERSION_INFO) $(LDFLAGS)
+libbrotlidec_la_CFLAGS = $(AM_CFLAGS) $(libbrotli_la_CFLAGS_EXTRA)
+libbrotlidec_la_CXXFLAGS =
+libbrotlidec_la_CPPFLAGS = $(AM_CPPFLAGS) $(libbrotli_la_CPPFLAGS_EXTRA)
+libbrotlidec_la_SOURCES = $(DECODE) $(DECODEHEADERS)
+
+libbrotlienc_la_CPPFLAGS_EXTRA = -DBROTLI_BUILDING_LIBRARY
+libbrotlienc_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLIENC_VERSION_INFO) $(LDFLAGS)
+libbrotlienc_la_CFLAGS = $(AM_CFLAGS) $(libbrotli_la_CFLAGS_EXTRA)
+libbrotlienc_la_CXXFLAGS =
+libbrotlienc_la_CPPFLAGS = $(AM_CPPFLAGS) $(libbrotli_la_CPPFLAGS_EXTRA)
+libbrotlienc_la_SOURCES = $(ENCODE) $(ENCODEHEADERS)
+
+# where to install the brotli headers
+libbrotlienc_ladir = $(includedir)
+libbrotlidec_ladir = $(includedir)
+

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,22 @@
+# !/bin/sh -e
+
+automake -a
+
+AUTORECONF=`which autoreconf 2>/dev/null`
+if test $? -ne 0; then
+  echo "No 'autoreconf' found. You must install the autoconf package."
+  exit 1
+fi
+
+# create m4 before autoreconf
+mkdir m4 2>/dev/null
+
+$AUTORECONF --install --force --symlink || exit $?
+
+echo
+echo "----------------------------------------------------------------"
+echo "Initialized build system. For a common configuration please run:"
+echo "----------------------------------------------------------------"
+echo
+echo "./configure"
+echo

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,15 @@
+AC_PREREQ(2.57)
+
+AC_INIT([brotli], [0.4.0], [-])
+AC_CONFIG_SRCDIR([dec/decode.h])
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([m4])
+LT_INIT
+AM_INIT_AUTOMAKE()
+AM_MAINTAINER_MODE
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
+AC_PROG_CXX
+
+AC_CONFIG_FILES([Makefile libbrotlienc.pc libbrotlidec.pc])
+AC_OUTPUT

--- a/libbrotlidec.pc.in
+++ b/libbrotlidec.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@dec
+Description: Brotli decoder library
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Libs: -L${libdir} -lbrotlidec
+Cflags: -I${includedir}

--- a/libbrotlienc.pc.in
+++ b/libbrotlienc.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@enc
+Description: Brotli encoder library
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Libs: -L${libdir} -lbrotlienc
+Cflags: -I${includedir}


### PR DESCRIPTION
Based on commit https://github.com/bagder/libbrotli/commit/e992cce7a17 after initial discussion in issue #326.

First take. This version unfortunately duplicate the list of sources from enc/Makefile and dec/Makefile, which I would rather avoid. It also doesn't use the `shared.mk` magic that the existing Makefiles use.

Run

```
$ ./autogen.sh
$ ./configue
$ make
$ make install
```

Any feedback on the approach? I decided to put the files in the root dir since that is a common convention. Let me know what you think.
# docs

`make install` puts the headers in $prefix/install/dec and $prefix/install/inc subdirectories to be used for applications.

This setup builds one encoder lib and one decoder lib. `libbrotlidec.pc` and `libbrotlienc.pc` are generated to help applications know how to link with them.

The `Makefile.am` file needs to be maintained and state the correct SONAME numbers for the generated shared libraries. They say 1.0.0. for both, but its really up to you guys to decide how to do them.
