### PR TITLE
Fix build with -Wshadow.

### DIFF
--- a/enc/block_splitter.cc
+++ b/enc/block_splitter.cc
@@ -485,14 +485,14 @@ void SplitBlock(const Command* cmds,
   {
     // Create a continuous array of distance prefixes.
     std::vector<uint16_t> distance_prefixes(num_commands);
-    size_t pos = 0;
+    size_t dist_pos = 0;
     for (size_t i = 0; i < num_commands; ++i) {
       const Command& cmd = cmds[i];
       if (cmd.copy_len() && cmd.cmd_prefix_ >= 128) {
-        distance_prefixes[pos++] = cmd.dist_prefix_;
+        distance_prefixes[dist_pos++] = cmd.dist_prefix_;
       }
     }
-    distance_prefixes.resize(pos);
+    distance_prefixes.resize(dist_pos);
     // Create the block split on the array of distance prefixes.
     SplitByteVector<kNumDistancePrefixes>(
         distance_prefixes,

--- a/enc/compress_fragment.cc
+++ b/enc/compress_fragment.cc
@@ -135,18 +135,18 @@ static void BuildAndStoreCommandPrefixCode(const uint32_t histogram[128],
   ConvertBitDepthsToSymbols(&depth[64], 64, &bits[64]);
   {
     // Create the bit length array for the full command alphabet.
-    uint8_t cmd_depth[704] = { 0 };
-    memcpy(cmd_depth, depth, 8);
-    memcpy(cmd_depth + 64, depth + 8, 8);
-    memcpy(cmd_depth + 128, depth + 16, 8);
-    memcpy(cmd_depth + 192, depth + 24, 8);
-    memcpy(cmd_depth + 384, depth + 32, 8);
+    uint8_t full_cmd_depth[704] = { 0 };
+    memcpy(full_cmd_depth, depth, 8);
+    memcpy(full_cmd_depth + 64, depth + 8, 8);
+    memcpy(full_cmd_depth + 128, depth + 16, 8);
+    memcpy(full_cmd_depth + 192, depth + 24, 8);
+    memcpy(full_cmd_depth + 384, depth + 32, 8);
     for (size_t i = 0; i < 8; ++i) {
-      cmd_depth[128 + 8 * i] = depth[40 + i];
-      cmd_depth[256 + 8 * i] = depth[48 + i];
-      cmd_depth[448 + 8 * i] = depth[56 + i];
+      full_cmd_depth[128 + 8 * i] = depth[40 + i];
+      full_cmd_depth[256 + 8 * i] = depth[48 + i];
+      full_cmd_depth[448 + 8 * i] = depth[56 + i];
     }
-    StoreHuffmanTree(cmd_depth, 704, tree, storage_ix, storage);
+    StoreHuffmanTree(full_cmd_depth, 704, tree, storage_ix, storage);
   }
   StoreHuffmanTree(&depth[64], 64, tree, storage_ix, storage);
 }

--- a/enc/compress_fragment_two_pass.cc
+++ b/enc/compress_fragment_two_pass.cc
@@ -85,18 +85,18 @@ static void BuildAndStoreCommandPrefixCode(
   ConvertBitDepthsToSymbols(&depth[64], 64, &bits[64]);
   {
     // Create the bit length array for the full command alphabet.
-    uint8_t cmd_depth[704] = { 0 };
-    memcpy(cmd_depth, depth + 24, 8);
-    memcpy(cmd_depth + 64, depth + 32, 8);
-    memcpy(cmd_depth + 128, depth + 40, 8);
-    memcpy(cmd_depth + 192, depth + 48, 8);
-    memcpy(cmd_depth + 384, depth + 56, 8);
+    uint8_t full_cmd_depth[704] = { 0 };
+    memcpy(full_cmd_depth, depth + 24, 8);
+    memcpy(full_cmd_depth + 64, depth + 32, 8);
+    memcpy(full_cmd_depth + 128, depth + 40, 8);
+    memcpy(full_cmd_depth + 192, depth + 48, 8);
+    memcpy(full_cmd_depth + 384, depth + 56, 8);
     for (size_t i = 0; i < 8; ++i) {
-      cmd_depth[128 + 8 * i] = depth[i];
-      cmd_depth[256 + 8 * i] = depth[8 + i];
-      cmd_depth[448 + 8 * i] = depth[16 + i];
+      full_cmd_depth[128 + 8 * i] = depth[i];
+      full_cmd_depth[256 + 8 * i] = depth[8 + i];
+      full_cmd_depth[448 + 8 * i] = depth[16 + i];
     }
-    StoreHuffmanTree(cmd_depth, 704, tree, storage_ix, storage);
+    StoreHuffmanTree(full_cmd_depth, 704, tree, storage_ix, storage);
   }
   StoreHuffmanTree(&depth[64], 64, tree, storage_ix, storage);
 }

--- a/enc/entropy_encode.cc
+++ b/enc/entropy_encode.cc
@@ -465,9 +465,9 @@ void ConvertBitDepthsToSymbols(const uint8_t *depth,
   next_code[0] = 0;
   {
     int code = 0;
-    for (int bits = 1; bits < kMaxBits; ++bits) {
-      code = (code + bl_count[bits - 1]) << 1;
-      next_code[bits] = static_cast<uint16_t>(code);
+    for (int bit = 1; bit < kMaxBits; ++bit) {
+      code = (code + bl_count[bit - 1]) << 1;
+      next_code[bit] = static_cast<uint16_t>(code);
     }
   }
   for (size_t i = 0; i < len; ++i) {

--- a/enc/literal_cost.cc
+++ b/enc/literal_cost.cc
@@ -79,31 +79,32 @@ static void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
   for (size_t i = 0; i < len; ++i) {
     if (i >= window_half) {
       // Remove a byte in the past.
-      size_t c = i < window_half + 1 ?
+      size_t past_c = i < window_half + 1 ?
           0 : data[(pos + i - window_half - 1) & mask];
-      size_t last_c = i < window_half + 2 ?
+      size_t past_last_c = i < window_half + 2 ?
           0 : data[(pos + i - window_half - 2) & mask];
-      size_t utf8_pos2 = UTF8Position(last_c, c, max_utf8);
-      --histogram[utf8_pos2][data[(pos + i - window_half) & mask]];
-      --in_window_utf8[utf8_pos2];
+      size_t past_utf8_pos2 = UTF8Position(past_last_c, past_c, max_utf8);
+      --histogram[past_utf8_pos2][data[(pos + i - window_half) & mask]];
+      --in_window_utf8[past_utf8_pos2];
     }
     if (i + window_half < len) {
       // Add a byte in the future.
-      size_t c = data[(pos + i + window_half - 1) & mask];
-      size_t last_c = data[(pos + i + window_half - 2) & mask];
-      size_t utf8_pos2 = UTF8Position(last_c, c, max_utf8);
-      ++histogram[utf8_pos2][data[(pos + i + window_half) & mask]];
-      ++in_window_utf8[utf8_pos2];
+      size_t future_c = data[(pos + i + window_half - 1) & mask];
+      size_t future_last_c = data[(pos + i + window_half - 2) & mask];
+      size_t future_utf8_pos2 = UTF8Position(future_last_c, future_c, max_utf8);
+      ++histogram[future_utf8_pos2][data[(pos + i + window_half) & mask]];
+      ++in_window_utf8[future_utf8_pos2];
     }
-    size_t c = i < 1 ? 0 : data[(pos + i - 1) & mask];
-    size_t last_c = i < 2 ? 0 : data[(pos + i - 2) & mask];
-    size_t utf8_pos = UTF8Position(last_c, c, max_utf8);
+    size_t current_c = i < 1 ? 0 : data[(pos + i - 1) & mask];
+    size_t current_last_c = i < 2 ? 0 : data[(pos + i - 2) & mask];
+    size_t current_utf8_pos = UTF8Position(current_last_c, current_c, max_utf8);
     size_t masked_pos = (pos + i) & mask;
-    size_t histo = histogram[utf8_pos][data[masked_pos]];
+    size_t histo = histogram[current_utf8_pos][data[masked_pos]];
     if (histo == 0) {
       histo = 1;
     }
-    double lit_cost = FastLog2(in_window_utf8[utf8_pos]) - FastLog2(histo);
+    double lit_cost =
+        FastLog2(in_window_utf8[current_utf8_pos]) - FastLog2(histo);
     lit_cost += 0.02905;
     if (lit_cost < 1.0) {
       lit_cost *= 0.5;


### PR DESCRIPTION
Local variable shadowing makes code quite confusing in most cases.

I'm not sure if the new variable names are correct in all those cases,
so feel free to rename them.