### PR TITLE
Update decoder. Add encoder interface wrapper.

### DIFF
--- a/dec/bit_reader.h
+++ b/dec/bit_reader.h
@@ -14,10 +14,6 @@
 #include "./port.h"
 #include "./types.h"
 
-#ifdef BROTLI_DECODE_DEBUG
-#include <stdio.h>
-#endif
-
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
@@ -66,13 +62,13 @@ typedef struct {
 } BrotliBitReaderState;
 
 /* Initializes the bitreader fields. */
-void BrotliInitBitReader(BrotliBitReader* const br);
+BROTLI_INTERNAL void BrotliInitBitReader(BrotliBitReader* const br);
 
 /* Ensures that accumulator is not empty. May consume one byte of input.
    Returns 0 if data is required but there is no input available.
    For BROTLI_ALIGNED_READ this function also prepares bit reader for aligned
    reading. */
-int BrotliWarmupBitReader(BrotliBitReader* const br);
+BROTLI_INTERNAL int BrotliWarmupBitReader(BrotliBitReader* const br);
 
 static BROTLI_INLINE void BrotliBitReaderSaveState(
     BrotliBitReader* const from, BrotliBitReaderState* to) {
@@ -298,10 +294,8 @@ static BROTLI_INLINE void BrotliBitReaderUnload(BrotliBitReader* br) {
 static BROTLI_INLINE void BrotliTakeBits(
   BrotliBitReader* const br, uint32_t n_bits, uint32_t* val) {
   *val = (uint32_t)BrotliGetBitsUnmasked(br) & BitMask(n_bits);
-#ifdef BROTLI_DECODE_DEBUG
-  printf("[BrotliReadBits]  %d %d %d val: %6x\n",
-         (int)br->avail_in, (int)br->bit_pos_, n_bits, (int)*val);
-#endif
+  BROTLI_LOG(("[BrotliReadBits]  %d %d %d val: %6x\n",
+      (int)br->avail_in, (int)br->bit_pos_, n_bits, (int)*val));
   BrotliDropBits(br, n_bits);
 }
 

--- a/dec/decode.h
+++ b/dec/decode.h
@@ -9,12 +9,13 @@
 #ifndef BROTLI_DEC_DECODE_H_
 #define BROTLI_DEC_DECODE_H_
 
-#include "./state.h"
 #include "./types.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
+
+typedef struct BrotliStateStruct BrotliState;
 
 typedef enum {
   /* Decoding error, e.g. corrupt input or memory allocation problem */
@@ -80,14 +81,21 @@ BrotliResult BrotliDecompressStream(size_t* available_in,
    Not to be confused with the built-in transformable dictionary of Brotli.
    The dictionary must exist in memory until decoding is done and is owned by
    the caller. To use:
-    1) initialize state with BrotliStateInit
-    2) use BrotliSetCustomDictionary
-    3) use BrotliDecompressStream
-    4) clean up with BrotliStateCleanup
+    1) Allocate and initialize state with BrotliCreateState
+    2) Use BrotliSetCustomDictionary
+    3) Use BrotliDecompressStream
+    4) Clean up and free state with BrotliDestroyState
 */
 void BrotliSetCustomDictionary(
     size_t size, const uint8_t* dict, BrotliState* s);
 
+/* Returns 1, if s is in a state where we have not read any input bytes yet,
+   and 0 otherwise */
+int BrotliStateIsStreamStart(const BrotliState* s);
+
+/* Returns 1, if s is in a state where we reached the end of the input and
+   produced all of the output, and 0 otherwise. */
+int BrotliStateIsStreamEnd(const BrotliState* s);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 } /* extern "C" */

--- a/dec/huffman.c
+++ b/dec/huffman.c
@@ -99,7 +99,6 @@ static BROTLI_INLINE int NextTableBitSize(const uint16_t* const count,
   return len - root_bits;
 }
 
-
 void BrotliBuildCodeLengthsHuffmanTable(HuffmanCode* table,
                                         const uint8_t* const code_lengths,
                                         uint16_t* count) {

--- a/dec/huffman.h
+++ b/dec/huffman.h
@@ -10,6 +10,7 @@
 #define BROTLI_DEC_HUFFMAN_H_
 
 #include "./types.h"
+#include "./port.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
@@ -36,27 +37,21 @@ typedef struct {
   uint16_t value;  /* symbol value or table offset */
 } HuffmanCode;
 
-
 /* Builds Huffman lookup table assuming code lengths are in symbol order. */
-void BrotliBuildCodeLengthsHuffmanTable(HuffmanCode* root_table,
-                                        const uint8_t* const code_lengths,
-                                        uint16_t* count);
+BROTLI_INTERNAL void BrotliBuildCodeLengthsHuffmanTable(HuffmanCode* root_table,
+    const uint8_t* const code_lengths, uint16_t* count);
 
 /* Builds Huffman lookup table assuming code lengths are in symbol order. */
 /* Returns size of resulting table. */
-uint32_t BrotliBuildHuffmanTable(HuffmanCode* root_table,
-                                 int root_bits,
-                                 const uint16_t* const symbol_lists,
-                                 uint16_t* count_arg);
+BROTLI_INTERNAL uint32_t BrotliBuildHuffmanTable(HuffmanCode* root_table,
+    int root_bits, const uint16_t* const symbol_lists, uint16_t* count_arg);
 
 /* Builds a simple Huffman table. The num_symbols parameter is to be */
 /* interpreted as follows: 0 means 1 symbol, 1 means 2 symbols, 2 means 3 */
 /* symbols, 3 means 4 symbols with lengths 2,2,2,2, 4 means 4 symbols with */
 /* lengths 1,2,3,3. */
-uint32_t BrotliBuildSimpleHuffmanTable(HuffmanCode* table,
-                                       int root_bits,
-                                       uint16_t* symbols,
-                                       uint32_t num_symbols);
+BROTLI_INTERNAL uint32_t BrotliBuildSimpleHuffmanTable(HuffmanCode* table,
+    int root_bits, uint16_t* symbols, uint32_t num_symbols);
 
 /* Contains a collection of Huffman trees with the same alphabet size. */
 typedef struct {

--- a/dec/state.c
+++ b/dec/state.c
@@ -15,6 +15,10 @@
 extern "C" {
 #endif
 
+/* Declared in decode.h */
+int BrotliStateIsStreamStart(const BrotliState* s);
+int BrotliStateIsStreamEnd(const BrotliState* s);
+
 static void* DefaultAllocFunc(void* opaque, size_t size) {
   BROTLI_UNUSED(opaque);
   return malloc(size);
@@ -75,7 +79,6 @@ void BrotliStateInitWithCustomAllocators(BrotliState* s,
   s->insert_copy_hgroup.htrees = NULL;
   s->distance_hgroup.codes = NULL;
   s->distance_hgroup.htrees = NULL;
-
 
   s->custom_dict = NULL;
   s->custom_dict_size = 0;

--- a/dec/state.h
+++ b/dec/state.h
@@ -12,6 +12,7 @@
 #include "./bit_reader.h"
 #include "./huffman.h"
 #include "./types.h"
+#include "./port.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
@@ -156,7 +157,6 @@ struct BrotliStateStruct {
   uint32_t repeat_code_len;
   uint32_t prev_code_len;
 
-
   int copy_length;
   int distance_code;
 
@@ -220,27 +220,19 @@ struct BrotliStateStruct {
   uint8_t* context_modes;
 };
 
-typedef struct BrotliStateStruct BrotliState;
+typedef struct BrotliStateStruct BrotliStateInternal;
+#define BrotliState BrotliStateInternal
 
-void BrotliStateInit(BrotliState* s);
-void BrotliStateInitWithCustomAllocators(BrotliState* s,
-                                         brotli_alloc_func alloc_func,
-                                         brotli_free_func free_func,
-                                         void* opaque);
-void BrotliStateCleanup(BrotliState* s);
-void BrotliStateMetablockBegin(BrotliState* s);
-void BrotliStateCleanupAfterMetablock(BrotliState* s);
-void BrotliHuffmanTreeGroupInit(BrotliState* s, HuffmanTreeGroup* group,
-                                uint32_t alphabet_size, uint32_t ntrees);
-void BrotliHuffmanTreeGroupRelease(BrotliState* s, HuffmanTreeGroup* group);
-
-/* Returns 1, if s is in a state where we have not read any input bytes yet,
-   and 0 otherwise */
-int BrotliStateIsStreamStart(const BrotliState* s);
-
-/* Returns 1, if s is in a state where we reached the end of the input and
-   produced all of the output, and 0 otherwise. */
-int BrotliStateIsStreamEnd(const BrotliState* s);
+BROTLI_INTERNAL void BrotliStateInit(BrotliState* s);
+BROTLI_INTERNAL void BrotliStateInitWithCustomAllocators(BrotliState* s,
+    brotli_alloc_func alloc_func, brotli_free_func free_func, void* opaque);
+BROTLI_INTERNAL void BrotliStateCleanup(BrotliState* s);
+BROTLI_INTERNAL void BrotliStateMetablockBegin(BrotliState* s);
+BROTLI_INTERNAL void BrotliStateCleanupAfterMetablock(BrotliState* s);
+BROTLI_INTERNAL void BrotliHuffmanTreeGroupInit(BrotliState* s,
+    HuffmanTreeGroup* group, uint32_t alphabet_size, uint32_t ntrees);
+BROTLI_INTERNAL void BrotliHuffmanTreeGroupRelease(BrotliState* s,
+    HuffmanTreeGroup* group);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }  /* extern "C" */

--- a/enc/compressor.h
+++ b/enc/compressor.h
@@ -1,0 +1,15 @@
+/* Copyright 2016 Google Inc. All Rights Reserved.
+
+   Distributed under MIT license.
+   See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+*/
+
+/* C++ API for Brotli compression. */
+
+#ifndef BROTLI_ENC_COMPRESSOR_H_
+#define BROTLI_ENC_COMPRESSOR_H_
+
+#include "./encode.h"
+#include "./streams.h"
+
+#endif  /* BROTLI_ENC_COMPRESSOR_H_ */

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -220,10 +220,9 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
   std::vector<uint8_t> output;
   const size_t kBufferSize = 65536;
   uint8_t* buffer = new uint8_t[kBufferSize];
-  BrotliState state;
-  BrotliStateInit(&state);
+  BrotliState* state = BrotliCreateState(0, 0, 0);
   if (custom_dictionary_length != 0) {
-    BrotliSetCustomDictionary(custom_dictionary_length, custom_dictionary, &state);
+    BrotliSetCustomDictionary(custom_dictionary_length, custom_dictionary, state);
   }
 
   BrotliResult result = BROTLI_RESULT_NEEDS_MORE_OUTPUT;
@@ -233,7 +232,7 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
     size_t total_out = 0;
     result = BrotliDecompressStream(&length, &input,
                                     &available_out, &next_out,
-                                    &total_out, &state);
+                                    &total_out, state);
     size_t used_out = kBufferSize - available_out;
     if (used_out != 0)
       output.insert(output.end(), buffer, buffer + used_out);
@@ -245,7 +244,7 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
     PyErr_SetString(BrotliError, "BrotliDecompress failed");
   }
   
-  BrotliStateCleanup(&state);
+  BrotliDestroyState(state);
   delete[] buffer;
 
   return ret;


### PR DESCRIPTION
 * condense printf in port.h; use BROTLI_LOG everywhere
 * mark non-exported functions with BROTLI_INTERNAL
 * use BROTLI_DUMP instead of (void)(BROTLI_FAILURE())
 * fix problems with CustomDictionary
 * make decode.h independent of state.h
 * fix "double-new-lines"
 * fix some strict compilation warnings
 * fix bro.cc compilation for MSVS
 * added compressor.h as a replacement for encode.h + streams.h