### PR TITLE
Fix compilation with VS2012

### DIFF
--- a/enc/fast_log.h
+++ b/enc/fast_log.h
@@ -124,8 +124,8 @@ static inline double FastLog2(size_t v) {
   if (v < sizeof(kLog2Table) / sizeof(kLog2Table[0])) {
     return kLog2Table[v];
   }
-#if defined(_MSC_VER) && _MSC_VER <= 1600
-  // Visual Studio 2010 does not have the log2() function defined, so we use
+#if defined(_MSC_VER) && _MSC_VER <= 1700
+  // Visual Studio 2012 does not have the log2() function defined, so we use
   // log() and a multiplication instead.
   static const double kLog2Inv = 1.4426950408889634f;
   return log(static_cast<double>(v)) * kLog2Inv;


### PR DESCRIPTION
The brotli code currently does not compile with Visual Studio 2012, because the code assumes that the `log2` function is supported by VIsual Studio 2012 and newer, which is not true.

This PR fixes the preprocessor check, so the workaround code is used with Visual Studio 2012 as well.
