### PR TITLE
Make encoder API more safe

### DIFF
--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -585,8 +585,8 @@ bool BrotliCompressor::WriteBrotliData(const bool is_last,
   const uint32_t mask = ringbuffer_->mask();
   
    /* Adding more blocks after "last" block is forbidden. */
-  if (s->is_last_block_emitted_) return false;
-  if (is_last) s->is_last_block_emitted_ = 1;
+  if (is_last_block_emitted_) return false;
+  if (is_last) is_last_block_emitted_ = 1;
 
   if (delta > input_block_size()) {
     return false;

--- a/enc/encode.cc
+++ b/enc/encode.cc
@@ -442,7 +442,8 @@ BrotliCompressor::BrotliCompressor(BrotliParams params)
       large_table_(NULL),
       cmd_code_numbits_(0),
       command_buf_(NULL),
-      literal_buf_(NULL) {
+      literal_buf_(NULL),
+      is_last_block_emitted_(0) {
   // Sanitize params.
   params_.quality = std::max(0, params_.quality);
   if (params_.lgwin < kMinWindowBits) {
@@ -582,6 +583,10 @@ bool BrotliCompressor::WriteBrotliData(const bool is_last,
   const uint64_t delta = input_pos_ - last_processed_pos_;
   const uint8_t* data = ringbuffer_->start();
   const uint32_t mask = ringbuffer_->mask();
+  
+   /* Adding more blocks after "last" block is forbidden. */
+  if (s->is_last_block_emitted_) return false;
+  if (is_last) s->is_last_block_emitted_ = 1;
 
   if (delta > input_block_size()) {
     return false;

--- a/enc/encode.h
+++ b/enc/encode.h
@@ -180,6 +180,8 @@ class BrotliCompressor {
   // Command and literal buffers for quality 1.
   uint32_t* command_buf_;
   uint8_t* literal_buf_;
+  
+  int is_last_block_emitted_;
 };
 
 // Compresses the data in input_buffer into encoded_buffer, and sets


### PR DESCRIPTION
Fix heap-overflow at quality 10-11 when WriteBrotliData is repeatedly invoked with is_last=true.

See Issue #346 