### PR TITLE
Add a "lib" target to the Makefile to build a static library: libbrotli.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 OS := $(shell uname)
-SOURCES = $(wildcard common/*.c) $(wildcard dec/*.c) $(wildcard enc/*.c) \
-          tools/bro.c
+LIBSOURCES = $(wildcard common/*.c) $(wildcard dec/*.c) $(wildcard enc/*.c)
+SOURCES = $(LIBSOURCES) tools/bro.c
 BINDIR = bin
 OBJDIR = $(BINDIR)/obj
+LIBOBJECTS = $(addprefix $(OBJDIR)/, $(LIBSOURCES:.c=.o))
 OBJECTS = $(addprefix $(OBJDIR)/, $(SOURCES:.c=.o))
+LIB_A = libbrotli.a
 EXECUTABLE = bro
 DIRS = $(OBJDIR)/common $(OBJDIR)/dec $(OBJDIR)/enc \
        $(OBJDIR)/tools $(BINDIR)/tmp
@@ -27,9 +29,13 @@ $(OBJECTS): $(DIRS)
 $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(OBJECTS) -lm -o $(BINDIR)/$(EXECUTABLE)
 
+lib: $(LIBOBJECTS)
+	rm -f $(LIB_A)
+	ar -crs $(LIB_A) $(LIBOBJECTS)
+
 test: $(EXECUTABLE)
 	tests/compatibility_test.sh
 	tests/roundtrip_test.sh
 
 clean:
-	rm -rf $(BINDIR)
+	rm -rf $(BINDIR) $(LIB_A)


### PR DESCRIPTION
This small change to the Makefile supports building a libbrotli.a archive of the encoding and decoding objects (not including the CLI tool object or running the test suite).  This provides an easy target for linking when brotli code is included in projects that use the encoding and decoding components.  This is only an extension, the previous behavior for other targets remain.

P.S. I like the approach of providing a simple, portable Makefile for building when an autoconfig/configure/make can be avoided.  This simplicity makes incorporation of brotli into small projects (that do not have their own autoconf/etc.) that much easier.  Thanks!