### PR TITLE
Fix python build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 case "$1" in
     "install")

--- a/.travis.sh
+++ b/.travis.sh
@@ -44,8 +44,12 @@ case "$1" in
     "after_success")
 	case "${BUILD_SYSTEM}" in
 	    "python")
-		source venv/bin/activate
-		pip wheel -w dist .
+		case "${TRAVIS_OS_NAME}" in
+		    "osx")
+			source venv/bin/activate
+			pip wheel -w dist .
+			;;
+		esac
 		;;
 	esac
 	;;

--- a/.travis.sh
+++ b/.travis.sh
@@ -36,13 +36,15 @@ case "$1" in
 		ctest -V
 		;;
 	    "python")
-                python setup.py build_ext test
+		source venv/bin/activate
+		python setup.py build_ext test
 		;;
 	esac
 	;;
     "after_success")
 	case "${BUILD_SYSTEM}" in
 	    "python")
+		source venv/bin/activate
 		pip wheel -w dist .
 		;;
 	esac

--- a/.travis.sh
+++ b/.travis.sh
@@ -36,7 +36,9 @@ case "$1" in
 		ctest -V
 		;;
 	    "python")
-		source venv/bin/activate
+		if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+			source venv/bin/activate
+		fi
 		python setup.py build_ext test
 		;;
 	esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,19 +159,11 @@ matrix:
     ## Python OS X builds
     ###
     - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=system PYTHON_VERSION=2.7
+      env: BUILD_SYSTEM=python INSTALL_TYPE=macpython PYTHON_VERSION=2.7.12
     - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=macpython PYTHON_VERSION=2.7.10
+      env: BUILD_SYSTEM=python INSTALL_TYPE=macpython PYTHON_VERSION=3.4.4
     - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=homebrew PYTHON_VERSION=2.7.10
-    - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=macpython PYTHON_VERSION=3.4.3
-    - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=homebrew PYTHON_VERSION=3.4.3
-    - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=macpython PYTHON_VERSION=3.5.0
-    - os: osx
-      env: BUILD_SYSTEM=python INSTALL_TYPE=homebrew PYTHON_VERSION=3.5.0
+      env: BUILD_SYSTEM=python INSTALL_TYPE=macpython PYTHON_VERSION=3.5.2
 
     ###
     ## Sanitizers

--- a/.travis.yml
+++ b/.travis.yml
@@ -243,4 +243,4 @@ deploy:
   on:
     repo: "google/brotli"
     tags: true
-    condition: "${BUILD_SYSTEM} = python || ${TRAVIS_OS_NAME} = osx"
+    condition: "${BUILD_SYSTEM} = python && ${TRAVIS_OS_NAME} = osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,7 @@ after_success:
 - ./.travis.sh after_success
 
 before_deploy:
-- if [ "${BUILD_SYSTEM}" = "python" ]; then export WHEELS=$(ls ./dist/*.whl); fi
+- if [ "${BUILD_SYSTEM}" = "python" ] && [ "${TRAVIS_OS_NAME}" = "osx" ]; then export WHEELS=$(ls ./dist/*.whl); fi
 
 deploy:
   provider: releases
@@ -243,4 +243,4 @@ deploy:
   on:
     repo: "google/brotli"
     tags: true
-    condition: "${BUILD_SYSTEM} = python"
+    condition: "${BUILD_SYSTEM} = python || ${TRAVIS_OS_NAME} = osx"


### PR DESCRIPTION
We need to source the virtual environment at the `script` and `after_success` stages inside`.travis.sh` script.

We can build and deploy only OSX wheels for now, but I will work on adding `manylinux1` support later.

There's no need to build wheels using homebrew python (64bit only), as the wheels produced by Mac Python (from Python.org) are "universal", so they will work on homebrew python as well. 