### PR TITLE
Bazel: use cc_library instead of cc_inc_library.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -56,18 +56,19 @@ filegroup(
     srcs = glob(["enc/*.c"]),
 )
 
-cc_inc_library(
+cc_library(
     name = "brotli",
     hdrs = [":public_headers"],
-    prefix = "include",
+    copts = STRICT_C_OPTIONS,
+    includes = ["include"],
 )
 
 cc_library(
     name = "brotli_common",
     srcs = [":common_sources"],
     hdrs = [":common_headers"],
-    deps = [":brotli"],
     copts = STRICT_C_OPTIONS,
+    deps = [":brotli"],
 )
 
 cc_library(


### PR DESCRIPTION
cc_inc_library is broken when used with external repositories
(see: https://github.com/bazelbuild/bazel/issues/1596), which
makes it a bit useless at the moment.

Switch to using cc_library with "includes" attribute to expose
public headers.

While there, fix order of attributes in ":brotli_common" target.