### PR TITLE
Bazel: temporarily disable ":bro" target.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -86,13 +86,13 @@ cc_library(
     deps = [":brotli_common"],
 )
 
-cc_binary(
-    name = "bro",
-    srcs = ["tools/bro.c"],
-    copts = STRICT_C_OPTIONS,
-    linkstatic = 1,
-    deps = [
-        ":brotli_dec",
-        ":brotli_enc",
-    ],
-)
+# cc_binary(
+#     name = "bro",
+#     srcs = ["tools/bro.c"],
+#     copts = STRICT_C_OPTIONS,
+#     linkstatic = 1,
+#     deps = [
+#         ":brotli_dec",
+#         ":brotli_enc",
+#     ],
+# )


### PR DESCRIPTION
Bazel doesn't like "tools" directory, which makes the whole
BUILD file unusable.