### PR TITLE
Bazel: link ":brotli_enc" with -lm.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -86,6 +86,7 @@ cc_library(
     srcs = [":enc_sources"],
     hdrs = [":enc_headers"],
     copts = STRICT_C_OPTIONS,
+    linkopts = ["-lm"],
     deps = [":brotli_common"],
 )
 


### PR DESCRIPTION
While this isn't strictly necessary with recent versions of Bazel
(which unconditionally add -lm to linkopts), building Brotli with
older versions of Bazel requires -lm to be added explicitly.