### PR TITLE
Create large window brotli, new incompatible compression format.

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -32,10 +32,12 @@
 #define BROTLI_NUM_DISTANCE_SHORT_CODES 16
 #define BROTLI_MAX_NPOSTFIX 3
 #define BROTLI_MAX_NDIRECT 120
-/* BROTLI_NUM_DISTANCE_SYMBOLS == 520 */
+#define BROTLI_MAX_DISTANCE_BITS 30U
+/* BROTLI_NUM_DISTANCE_SYMBOLS == 616 */
 #define BROTLI_NUM_DISTANCE_SYMBOLS (BROTLI_NUM_DISTANCE_SHORT_CODES + \
                                      BROTLI_MAX_NDIRECT +              \
-                                     (24 << (BROTLI_MAX_NPOSTFIX + 1)))
+                                     (BROTLI_MAX_DISTANCE_BITS <<      \
+                                      (BROTLI_MAX_NPOSTFIX + 1)))
 
 /* 7.1. Context modes and context ID lookup for literals */
 /* "context IDs for literals are in the range of 0..63" */

--- a/enc/backward_references.h
+++ b/enc/backward_references.h
@@ -39,6 +39,7 @@ typedef struct ZopfliNode {
      highest 7 bit contains distance short code + 1 (or zero if no short code)
   */
   uint32_t distance;
+  uint32_t short_code;
   /* number of literal inserts before this copy */
   uint32_t insert_length;
 

--- a/enc/brotli_bit_stream.c
+++ b/enc/brotli_bit_stream.c
@@ -964,6 +964,11 @@ void BrotliStoreMetaBlock(MemoryManager* m,
   size_t pos = start_pos;
   size_t i;
   size_t num_distance_codes;
+  HuffmanTree* tree;
+  BlockEncoder literal_enc;
+  BlockEncoder command_enc;
+  BlockEncoder distance_enc;
+  
   if (lgwin == 30) {
     num_distance_codes = BROTLI_NUM_DISTANCE_SHORT_CODES +
         num_direct_distance_codes +
@@ -972,10 +977,6 @@ void BrotliStoreMetaBlock(MemoryManager* m,
     num_distance_codes = BROTLI_NUM_DISTANCE_SHORT_CODES +
         num_direct_distance_codes + (48U << distance_postfix_bits);
   }
-  HuffmanTree* tree;
-  BlockEncoder literal_enc;
-  BlockEncoder command_enc;
-  BlockEncoder distance_enc;
 
   StoreCompressedMetaBlockHeader(is_last, length, storage_ix, storage);
 

--- a/enc/brotli_bit_stream.h
+++ b/enc/brotli_bit_stream.h
@@ -55,6 +55,7 @@ BROTLI_INTERNAL void BrotliStoreMetaBlock(MemoryManager* m,
                                           const Command* commands,
                                           size_t n_commands,
                                           const MetaBlockSplit* mb,
+                                          int lgwin,
                                           size_t* storage_ix,
                                           uint8_t* storage);
 

--- a/enc/metablock.c
+++ b/enc/metablock.c
@@ -488,6 +488,7 @@ void BrotliBuildMetaBlockGreedyWithContexts(MemoryManager* m,
 
 void BrotliOptimizeHistograms(size_t num_direct_distance_codes,
                               size_t distance_postfix_bits,
+                              int lgwin,
                               MetaBlockSplit* mb) {
   uint8_t good_for_rle[BROTLI_NUM_COMMAND_SYMBOLS];
   size_t num_distance_codes;
@@ -501,8 +502,14 @@ void BrotliOptimizeHistograms(size_t num_direct_distance_codes,
                                       mb->command_histograms[i].data_,
                                       good_for_rle);
   }
-  num_distance_codes = BROTLI_NUM_DISTANCE_SHORT_CODES +
-      num_direct_distance_codes + (48u << distance_postfix_bits);
+  if (lgwin == 30) {
+    num_distance_codes = BROTLI_NUM_DISTANCE_SHORT_CODES +
+        num_direct_distance_codes +
+        ((2 * BROTLI_MAX_DISTANCE_BITS) << distance_postfix_bits);
+  } else {
+    num_distance_codes = BROTLI_NUM_DISTANCE_SHORT_CODES +
+        num_direct_distance_codes + (48U << distance_postfix_bits);
+  }
   for (i = 0; i < mb->distance_histograms_size; ++i) {
     BrotliOptimizeHuffmanCountsForRle(num_distance_codes,
                                       mb->distance_histograms[i].data_,

--- a/enc/metablock.h
+++ b/enc/metablock.h
@@ -101,6 +101,7 @@ BROTLI_INTERNAL void BrotliBuildMetaBlockGreedyWithContexts(
 
 BROTLI_INTERNAL void BrotliOptimizeHistograms(size_t num_direct_distance_codes,
                                               size_t distance_postfix_bits,
+                                              int lgwin,
                                               MetaBlockSplit* mb);
 
 #if defined(__cplusplus) || defined(c_plusplus)

--- a/enc/prefix.h
+++ b/enc/prefix.h
@@ -23,10 +23,12 @@ static BROTLI_INLINE void PrefixEncodeCopyDistance(size_t distance_code,
                                                    size_t num_direct_codes,
                                                    size_t postfix_bits,
                                                    uint16_t* code,
+                                                   uint32_t* extra_bits_size,
                                                    uint32_t* extra_bits) {
   if (distance_code < BROTLI_NUM_DISTANCE_SHORT_CODES + num_direct_codes) {
     *code = (uint16_t)distance_code;
     *extra_bits = 0;
+    *extra_bits_size = 0;
     return;
   } else {
     size_t dist = ((size_t)1 << (postfix_bits + 2u)) +
@@ -40,8 +42,8 @@ static BROTLI_INLINE void PrefixEncodeCopyDistance(size_t distance_code,
     *code = (uint16_t)(
         (BROTLI_NUM_DISTANCE_SHORT_CODES + num_direct_codes +
          ((2 * (nbits - 1) + prefix) << postfix_bits) + postfix));
-    *extra_bits = (uint32_t)(
-        (nbits << 24) | ((dist - offset) >> postfix_bits));
+    *extra_bits = (uint32_t)((dist - offset) >> postfix_bits);
+    *extra_bits_size = (uint32_t)nbits;
   }
 }
 

--- a/enc/quality.h
+++ b/enc/quality.h
@@ -65,8 +65,10 @@ static BROTLI_INLINE void SanitizeParams(BrotliEncoderParams* params) {
       BROTLI_MAX(int, BROTLI_MIN_QUALITY, params->quality));
   if (params->lgwin < kBrotliMinWindowBits) {
     params->lgwin = kBrotliMinWindowBits;
-  } else if (params->lgwin > kBrotliMaxWindowBits) {
+  } else if (params->lgwin >= kBrotliMaxWindowBits) {
     params->lgwin = kBrotliMaxWindowBits;
+  } else if (params->lgwin > 24) {
+    params->lgwin = 24;
   }
 }
 

--- a/include/brotli/encode.h
+++ b/include/brotli/encode.h
@@ -10,13 +10,14 @@
 #define BROTLI_ENC_ENCODE_H_
 
 #include <brotli/types.h>
+#include "../common/constants.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
 
-static const int kBrotliMaxWindowBits = 24;
 static const int kBrotliMinWindowBits = 10;
+static const int kBrotliMaxWindowBits = BROTLI_MAX_DISTANCE_BITS;
 static const int kBrotliMinInputBlockBits = 16;
 static const int kBrotliMaxInputBlockBits = 24;
 

--- a/tools/bro.c
+++ b/tools/bro.c
@@ -155,7 +155,7 @@ static void ParseArgv(int argc, char **argv,
         if (!ParseQuality(argv[k + 1], lgwin)) {
           goto error;
         }
-        if (*lgwin < 10 || *lgwin >= 25) {
+        if (*lgwin < 10 || (*lgwin >= 25 && *lgwin != 30)) {
           goto error;
         }
         ++k;


### PR DESCRIPTION
Large window brotli is a brotli version that can use 30-bit (1GB) window. It uses the reserved short-code `0010001` to indicate 30-bit window, therefore breaking [section 9.1 of RFC 7932](https://tools.ietf.org/html/rfc7932#section-9.1).

This is an experimental change, so that brotli can be more competitive on large inputs.

The compression ratio on enwik9 for quality 11 went from 4.47 for 24-bit window to 5.02 for 30-bit window. Also, on [10GB corpus](http://mattmahoney.net/dc/10gb.html) the compression ratio for quality 10 and 11 increased from 2.52 and 2.54 to 2.78 and 2.80 respectively.

Additionally, large window brotli has been very useful in researching brotli distance encoding and exploring patching possibilities.