### PR TITLE
Update decoder

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -32,10 +32,12 @@
 #define BROTLI_NUM_DISTANCE_SHORT_CODES 16
 #define BROTLI_MAX_NPOSTFIX 3
 #define BROTLI_MAX_NDIRECT 120
+#define BROTLI_MAX_DISTANCE_BITS 24U
 /* BROTLI_NUM_DISTANCE_SYMBOLS == 520 */
 #define BROTLI_NUM_DISTANCE_SYMBOLS (BROTLI_NUM_DISTANCE_SHORT_CODES + \
                                      BROTLI_MAX_NDIRECT +              \
-                                     (24 << (BROTLI_MAX_NPOSTFIX + 1)))
+                                     (BROTLI_MAX_DISTANCE_BITS <<      \
+                                      (BROTLI_MAX_NPOSTFIX + 1)))
 
 /* 7.1. Context modes and context ID lookup for literals */
 /* "context IDs for literals are in the range of 0..63" */

--- a/common/port.h
+++ b/common/port.h
@@ -96,10 +96,26 @@ OR:
 #define BROTLI_INLINE __forceinline
 #endif  /* _MSC_VER */
 
+#if !defined(__cplusplus) && !defined(c_plusplus) && \
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
+#define BROTLI_RESTRICT restrict
+#elif BROTLI_GCC_VERSION > 295 || defined(__llvm__)
+#define BROTLI_RESTRICT __restrict
+#else
+#define BROTLI_RESTRICT
+#endif
+
 #if BROTLI_MODERN_COMPILER || __has_attribute(noinline)
 #define BROTLI_NOINLINE __attribute__((noinline))
 #else
 #define BROTLI_NOINLINE
+#endif
+
+
+#if BROTLI_MODERN_COMPILER || __has_attribute(deprecated)
+#define BROTLI_DEPRECATED __attribute__((deprecated))
+#else
+#define BROTLI_DEPRECATED
 #endif
 
 #define BROTLI_UNUSED(X) (void)(X)

--- a/dec/bit_reader.h
+++ b/dec/bit_reader.h
@@ -18,13 +18,7 @@
 extern "C" {
 #endif
 
-#if (BROTLI_64_BITS)
-#define BROTLI_SHORT_FILL_BIT_WINDOW_READ 4
-typedef uint64_t reg_t;
-#else
-#define BROTLI_SHORT_FILL_BIT_WINDOW_READ 2
-typedef uint32_t reg_t;
-#endif
+#define BROTLI_SHORT_FILL_BIT_WINDOW_READ (sizeof(reg_t) >> 1)
 
 static const uint32_t kBitMask[33] = { 0x0000,
     0x00000001, 0x00000003, 0x00000007, 0x0000000F,
@@ -341,23 +335,6 @@ static BROTLI_INLINE BROTLI_BOOL BrotliJumpToByteBoundary(BrotliBitReader* br) {
     BrotliTakeBits(br, pad_bits_count, &pad_bits);
   }
   return TO_BROTLI_BOOL(pad_bits == 0);
-}
-
-/* Peeks a byte at specified offset.
-   Precondition: bit reader is parked to a byte boundary.
-   Returns -1 if operation is not feasible. */
-static BROTLI_INLINE int BrotliPeekByte(BrotliBitReader* br, size_t offset) {
-  uint32_t available_bits = BrotliGetAvailableBits(br);
-  size_t bytes_left = available_bits >> 3;
-  BROTLI_DCHECK((available_bits & 7) == 0);
-  if (offset < bytes_left) {
-    return (BrotliGetBitsUnmasked(br) >> (unsigned)(offset << 3)) & 0xFF;
-  }
-  offset -= bytes_left;
-  if (offset < br->avail_in) {
-    return br->next_in[offset];
-  }
-  return -1;
 }
 
 /* Copies remaining input bytes stored in the bit reader to the output. Value

--- a/dec/huffman.c
+++ b/dec/huffman.c
@@ -21,7 +21,8 @@ extern "C" {
 #define BROTLI_REVERSE_BITS_MAX 8
 
 #ifdef BROTLI_RBIT
-#define BROTLI_REVERSE_BITS_BASE (32 - BROTLI_REVERSE_BITS_MAX)
+#define BROTLI_REVERSE_BITS_BASE \
+  ((sizeof(reg_t) << 3) - BROTLI_REVERSE_BITS_MAX)
 #else
 #define BROTLI_REVERSE_BITS_BASE 0
 static uint8_t kReverseBits[1 << BROTLI_REVERSE_BITS_MAX] = {
@@ -61,12 +62,12 @@ static uint8_t kReverseBits[1 << BROTLI_REVERSE_BITS_MAX] = {
 #endif  /* BROTLI_RBIT */
 
 #define BROTLI_REVERSE_BITS_LOWEST \
-  (1U << (BROTLI_REVERSE_BITS_MAX - 1 + BROTLI_REVERSE_BITS_BASE))
+  ((reg_t)1 << (BROTLI_REVERSE_BITS_MAX - 1 + BROTLI_REVERSE_BITS_BASE))
 
 /* Returns reverse(num >> BROTLI_REVERSE_BITS_BASE, BROTLI_REVERSE_BITS_MAX),
    where reverse(value, len) is the bit-wise reversal of the len least
    significant bits of value. */
-static BROTLI_INLINE uint32_t BrotliReverseBits(uint32_t num) {
+static BROTLI_INLINE reg_t BrotliReverseBits(reg_t num) {
 #ifdef BROTLI_RBIT
   return BROTLI_RBIT(num);
 #else
@@ -103,12 +104,12 @@ static BROTLI_INLINE int NextTableBitSize(const uint16_t* const count,
 void BrotliBuildCodeLengthsHuffmanTable(HuffmanCode* table,
                                         const uint8_t* const code_lengths,
                                         uint16_t* count) {
-  HuffmanCode code;   /* current table entry */
-  int symbol;         /* symbol index in original or sorted table */
-  uint32_t key;       /* prefix code */
-  uint32_t key_step;  /* prefix code addend */
-  int step;           /* step size to replicate values in current table */
-  int table_size;     /* size of current table */
+  HuffmanCode code; /* current table entry */
+  int symbol;       /* symbol index in original or sorted table */
+  reg_t key;        /* prefix code */
+  reg_t key_step;   /* prefix code addend */
+  int step;         /* step size to replicate values in current table */
+  int table_size;   /* size of current table */
   int sorted[BROTLI_CODE_LENGTH_CODES];  /* symbols sorted by code length */
   /* offsets in sorted table for each length */
   int offset[BROTLI_HUFFMAN_MAX_CODE_LENGTH_CODE_LENGTH + 1];
@@ -143,7 +144,7 @@ void BrotliBuildCodeLengthsHuffmanTable(HuffmanCode* table,
   if (offset[0] == 0) {
     code.bits = 0;
     code.value = (uint16_t)sorted[0];
-    for (key = 0; key < (uint32_t)table_size; ++key) {
+    for (key = 0; key < (reg_t)table_size; ++key) {
       table[key] = code;
     }
     return;
@@ -171,18 +172,18 @@ uint32_t BrotliBuildHuffmanTable(HuffmanCode* root_table,
                                  int root_bits,
                                  const uint16_t* const symbol_lists,
                                  uint16_t* count) {
-  HuffmanCode code;       /* current table entry */
-  HuffmanCode* table;     /* next available space in table */
-  int len;                /* current code length */
-  int symbol;             /* symbol index in original or sorted table */
-  uint32_t key;           /* prefix code */
-  uint32_t key_step;      /* prefix code addend */
-  uint32_t sub_key;       /* 2nd level table prefix code */
-  uint32_t sub_key_step;  /* 2nd level table prefix code addend */
-  int step;               /* step size to replicate values in current table */
-  int table_bits;         /* key length of current table */
-  int table_size;         /* size of current table */
-  int total_size;         /* sum of root table size and 2nd level table sizes */
+  HuffmanCode code;    /* current table entry */
+  HuffmanCode* table;  /* next available space in table */
+  int len;             /* current code length */
+  int symbol;          /* symbol index in original or sorted table */
+  reg_t key;           /* prefix code */
+  reg_t key_step;      /* prefix code addend */
+  reg_t sub_key;       /* 2nd level table prefix code */
+  reg_t sub_key_step;  /* 2nd level table prefix code addend */
+  int step;            /* step size to replicate values in current table */
+  int table_bits;      /* key length of current table */
+  int table_size;      /* size of current table */
+  int total_size;      /* sum of root table size and 2nd level table sizes */
   int max_length = -1;
   int bits;
   int bits_count;

--- a/dec/state.c
+++ b/dec/state.c
@@ -60,6 +60,9 @@ void BrotliDecoderStateInitWithCustomAllocators(BrotliDecoderState* s,
   s->block_type_trees = NULL;
   s->block_len_trees = NULL;
   s->ringbuffer = NULL;
+  s->ringbuffer_size = 0;
+  s->new_ringbuffer_size = 0;
+  s->ringbuffer_mask = 0;
 
   s->context_map = NULL;
   s->context_modes = NULL;

--- a/dec/state.h
+++ b/dec/state.h
@@ -115,7 +115,6 @@ struct BrotliDecoderStateStruct {
 
   int pos;
   int max_backward_distance;
-  int max_backward_distance_minus_custom_dict_size;
   int max_distance;
   int ringbuffer_size;
   int ringbuffer_mask;
@@ -162,7 +161,7 @@ struct BrotliDecoderStateStruct {
 
   /* For partial write operations */
   size_t rb_roundtrips;  /* How many times we went around the ringbuffer */
-  size_t partial_pos_out;  /* How much output to the user in total (<= rb) */
+  size_t partial_pos_out;  /* How much output to the user in total */
 
   /* For ReadHuffmanCode */
   uint32_t symbol;
@@ -215,6 +214,8 @@ struct BrotliDecoderStateStruct {
   unsigned int should_wrap_ringbuffer : 1;
   unsigned int size_nibbles : 8;
   uint32_t window_bits;
+
+  int new_ringbuffer_size;
 
   uint32_t num_literal_htrees;
   uint8_t* context_map;

--- a/include/brotli/decode.h
+++ b/include/brotli/decode.h
@@ -126,8 +126,8 @@ BrotliDecoderResult BrotliDecoderDecompressStream(
    be ignored. The dictionary must exist in memory until decoding is done and
    is owned by the caller. To use:
     1) Allocate and initialize state with BrotliCreateInstance
-    2) Use BrotliSetCustomDictionary
-    3) Use BrotliDecompressStream
+    2) Use BrotliDecoderSetCustomDictionary
+    3) Use BrotliDecoderDecompressStream
     4) Clean up and free state with BrotliDestroyState
 */
 void BrotliDecoderSetCustomDictionary(
@@ -161,7 +161,7 @@ BROTLI_BOOL BrotliDecoderIsUsed(const BrotliDecoderState* s);
    and produced all of the output; returns false otherwise. */
 BROTLI_BOOL BrotliDecoderIsFinished(const BrotliDecoderState* s);
 
-/* Returns detailed error code after BrotliDecompressStream returns
+/* Returns detailed error code after BrotliDecoderDecompressStream returns
    BROTLI_DECODER_RESULT_ERROR. */
 BrotliDecoderErrorCode BrotliDecoderGetErrorCode(const BrotliDecoderState* s);
 
@@ -169,41 +169,6 @@ const char* BrotliDecoderErrorString(BrotliDecoderErrorCode c);
 
 /* Decoder version. Look at BROTLI_VERSION for more information. */
 uint32_t BrotliDecoderVersion(void);
-
-/* DEPRECATED >>> */
-typedef enum {
-  BROTLI_RESULT_ERROR = 0,
-  BROTLI_RESULT_SUCCESS = 1,
-  BROTLI_RESULT_NEEDS_MORE_INPUT = 2,
-  BROTLI_RESULT_NEEDS_MORE_OUTPUT = 3
-} BrotliResult;
-typedef enum {
-#define BROTLI_COMMA_ ,
-#define BROTLI_ERROR_CODE_ENUM_ITEM_(PREFIX, NAME, CODE) \
-    BROTLI ## PREFIX ## NAME = CODE
-  BROTLI_DECODER_ERROR_CODES_LIST(BROTLI_ERROR_CODE_ENUM_ITEM_, BROTLI_COMMA_)
-#undef BROTLI_ERROR_CODE_ENUM_ITEM_
-#undef BROTLI_COMMA_
-} BrotliErrorCode;
-typedef struct BrotliStateStruct BrotliState;
-BrotliState* BrotliCreateState(
-    brotli_alloc_func alloc, brotli_free_func free, void* opaque);
-void BrotliDestroyState(BrotliState* state);
-BROTLI_BOOL BrotliDecompressedSize(
-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size);
-BrotliResult BrotliDecompressBuffer(
-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
-    uint8_t* decoded_buffer);
-BrotliResult BrotliDecompressStream(
-    size_t* available_in, const uint8_t** next_in, size_t* available_out,
-    uint8_t** next_out, size_t* total_out, BrotliState* s);
-void BrotliSetCustomDictionary(
-    size_t size, const uint8_t* dict, BrotliState* s);
-BROTLI_BOOL BrotliStateIsStreamStart(const BrotliState* s);
-BROTLI_BOOL BrotliStateIsStreamEnd(const BrotliState* s);
-BrotliErrorCode BrotliGetErrorCode(const BrotliState* s);
-const char* BrotliErrorString(BrotliErrorCode c);
-/* <<< DEPRECATED */
 
 #if defined(__cplusplus) || defined(c_plusplus)
 } /* extern "C" */

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -223,19 +223,18 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
   std::vector<uint8_t> output;
   const size_t kBufferSize = 65536;
   uint8_t* buffer = new uint8_t[kBufferSize];
-  BrotliState* state = BrotliCreateState(0, 0, 0);
+  BrotliDecoderState* state = BrotliDecoderCreateInstance(0, 0, 0);
   if (custom_dictionary_length != 0) {
-    BrotliSetCustomDictionary(custom_dictionary_length, custom_dictionary, state);
+    BrotliDecoderSetCustomDictionary(state, custom_dictionary_length, custom_dictionary);
   }
 
-  BrotliResult result = BROTLI_RESULT_NEEDS_MORE_OUTPUT;
-  while (result == BROTLI_RESULT_NEEDS_MORE_OUTPUT) {
+  BrotliDecoderResult result = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
+  while (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
     size_t available_out = kBufferSize;
     uint8_t* next_out = buffer;
-    size_t total_out = 0;
-    result = BrotliDecompressStream(&length, &input,
-                                    &available_out, &next_out,
-                                    &total_out, state);
+    result = BrotliDecoderDecompressStream(&length, &input,
+                                           &available_out, &next_out,
+                                           0, state);
     size_t used_out = kBufferSize - available_out;
     if (used_out != 0)
       output.insert(output.end(), buffer, buffer + used_out);
@@ -247,7 +246,7 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
     PyErr_SetString(BrotliError, "BrotliDecompress failed");
   }
   
-  BrotliDestroyState(state);
+  BrotliDecoderDestroyInstance(state);
   delete[] buffer;
 
   return ret;

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -238,7 +238,7 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
     if (used_out != 0)
       output.insert(output.end(), buffer, buffer + used_out);
   }
-  ok = result == BROTLI_RESULT_SUCCESS;
+  ok = result == BROTLI_DECODER_RESULT_SUCCESS;
   if (ok) {
     ret = PyBytes_FromStringAndSize((char*)(output.size() ? &output[0] : NULL), output.size());
   } else {

--- a/python/brotlimodule.cc
+++ b/python/brotlimodule.cc
@@ -232,9 +232,8 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
   while (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
     size_t available_out = kBufferSize;
     uint8_t* next_out = buffer;
-    result = BrotliDecoderDecompressStream(&length, &input,
-                                           &available_out, &next_out,
-                                           0, state);
+    result = BrotliDecoderDecompressStream(state, &length, &input,
+                                           &available_out, &next_out, 0);
     size_t used_out = kBufferSize - available_out;
     if (used_out != 0)
       output.insert(output.end(), buffer, buffer + used_out);

--- a/tools/bro.c
+++ b/tools/bro.c
@@ -258,8 +258,8 @@ static void CopyStat(const char* input_path, const char* output_path) {
   times.modtime = statbuf.st_mtime;
   utime(output_path, &times);
   chmod(output_path, statbuf.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO));
-  chown(output_path, (__uid_t)-1, statbuf.st_gid);
-  chown(output_path, statbuf.st_uid, (__gid_t)-1);
+  chown(output_path, (uid_t)-1, statbuf.st_gid);
+  chown(output_path, statbuf.st_uid, (gid_t)-1);
 }
 
 /* Result ownersip is passed to caller.


### PR DESCRIPTION
 * use `BROTLI_MAX_DISTANCE_BITS` instead of magic constant
 * introduce `BROTLI_DEPRECATED`
 * move `BROTLI_RESTRICT` to `common/port.h`
 * promote `reg_t` to `dec/port.h`
 * remove deprecated decoder API
 * more optimistic ring-buffer allocation
 * fix MSVC warnings
 * fix (not tested) for ARM 64-bit RBIT