### PR TITLE
Python: Update README with information about code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ See [Premake5](https://premake.github.io/)
 
 #### Python
 
-The basic commands to build, test and install the Python binding are:
+The basic commands to build, test, and install the Python module are:
 
     $ python setup.py build_ext test
     $ python setup.py install
+
+See the [Python readme](python/README.md) for more details.
 
 ### Benchmarks
 * [Squash Compression Benchmark](https://quixdb.github.io/squash-benchmark/) / [Unstable Squash Compression Benchmark](https://quixdb.github.io/squash-benchmark/unstable/)

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,38 @@
-This directory contains Python brotli wrapper module and roundtrip tests.
+This directory contains the code for the Python `brotli` module,
+`bro.py` tool, and roundtrip tests.
 
-To build module execute `python setup.py build_ext` from root project directory.
 
-To test module run `python setup.py test`.
+### Development
+
+To build the module, execute the following from the root project
+directory:
+
+    $ python setup.py build_ext
+
+To test the module, execute the following from the root project
+directory:
+
+    $ python setup.py test
+
+
+### Code Style
+
+Brotli's code follows the [Google Python Style Guide][].  To
+automatically format your code, install [YAPF][]:
+
+    $ pip install yapf
+
+Then, either format a single file:
+
+    $ yapf --in-place FILE
+
+Or, format all files in a directory:
+
+    $ yapf --in-place --recursive DIR
+
+See the [YAPF usage][] documentation for more information.
+
+
+[Google Python Style Guide]: https://google.github.io/styleguide/pyguide.html
+[YAPF]: https://github.com/google/yapf
+[YAPF usage]: https://github.com/google/yapf#usage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [build]
 build-base=bin
 
+[yapf]
+based_on_style=google


### PR DESCRIPTION
Also, add a `yapf` section to `setup.cfg` to ensure YAPF runs
format code with the Google style.