### PR TITLE
Python: Support streamed compression with the Compressor object

### DIFF
--- a/python/brotli.py
+++ b/python/brotli.py
@@ -34,7 +34,7 @@ def compress(string, mode=MODE_GENERIC, quality=11, lgwin=22, lgblock=0,
         Range is 16 to 24. If set to 0, the value will be set based on the
         quality. Defaults to 0.
       dictionary (bytes, optional): Custom dictionary. Only last sliding window
-         size bytes will be used.
+        size bytes will be used.
 
     Returns:
       The compressed byte string.
@@ -44,7 +44,7 @@ def compress(string, mode=MODE_GENERIC, quality=11, lgwin=22, lgblock=0,
     """
     compressor = _brotli.Compressor(mode=mode, quality=quality, lgwin=lgwin,
                                     lgblock=lgblock, dictionary=dictionary)
-    return compressor.compress(string)
+    return compressor.process(string) + compressor.finish()
 
 # Decompress a compressed byte string.
 decompress = _brotli.decompress


### PR DESCRIPTION
Add `flush` and `finish` methods to the `Compressor` object in
the extension module and change `compress` to only process data.
Now, one or more `compress` calls followed by a `finish` call
will be equivalent to a module-level `compress` call.

Note: To maximize the compression efficiency (and match
underlying Brotli behavior, the `Compressor` object `compress`
method does not guarantee all input is immediately written to
output. To ensure immediate output, call `flush` to manually
flush the compression buffer. Extraneous flushing can increase
the size, but may be required when processing streaming data.

---

_edited Oct 19: see updated description in commit and the thread below_