### PR TITLE
Build shared libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 2.8.6)
 
 project(brotli)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 # If Brotli is being bundled in another project, we don't want to
 # install anything.  However, we want to let people override this, so
 # we'll use the BROTLI_BUNDLED_MODE variable to let them do that; just
@@ -151,9 +153,12 @@ foreach(lib brotlicommon brotlidec brotlienc)
   set_target_properties(${lib} PROPERTIES
     VERSION ${BROTLI_VERSION_MAJOR}.${BROTLI_VERSION_MINOR}.${BROTLI_VERSION_REVISION}
     POSITION_INDEPENDENT_CODE TRUE)
+  string(TOUPPER "${lib}" LIB)
+  set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION" )
 
   set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${BROTLI_INCLUDE_DIRS}")
 endforeach()
+
 if (BUILD_SHARED_LIBS)
   target_link_libraries(brotlidec brotlicommon)
   target_link_libraries(brotlienc brotlicommon)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ mark_as_advanced(BROTLI_BUNDLED_MODE)
 # When building shared libraries it is important to set the correct rpath.
 # See https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH
 if (BUILD_SHARED_LIBS)
+  add_definitions(-DBROTLI_SHARED_COMPILATION)
   set(CMAKE_SKIP_BUILD_RPATH FALSE)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -36,7 +37,7 @@ if (BUILD_SHARED_LIBS)
   endif()
 endif()
 
-# Parse version information from common/version.h.  Normally we would
+# Parse version information from common/version.h. Normally we would
 # define these values here and write them out to configuration file(s)
 # (i.e., config.h), but in this case we parse them from
 # common/version.h to be less intrusive.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ The basic commands to build, test and install brotli are:
     $ make install
 
 You can use other [CMake](https://cmake.org/) configuration. For example, to
-build shared libraries and use a custom installation directory:
+build static libraries and use a custom installation directory:
 
     $ mkdir out-shared && \
       cd out-shared && \
-      cmake .. -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX='/my/install/dir/'
+      cmake .. -DBUILD_SHARED_LIBS=0 -DCMAKE_INSTALL_PREFIX='/my/install/dir/'
     $ make install
 
 #### Premake5

--- a/common/dictionary.h
+++ b/common/dictionary.h
@@ -9,15 +9,16 @@
 #ifndef BROTLI_COMMON_DICTIONARY_H_
 #define BROTLI_COMMON_DICTIONARY_H_
 
+#include <brotli/port.h>
 #include <brotli/types.h>
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
 
-extern const uint8_t kBrotliDictionary[122784];
-extern const uint32_t kBrotliDictionaryOffsetsByLength[25];
-extern const uint8_t kBrotliDictionarySizeBitsByLength[25];
+BROTLI_COMMON_API extern const uint8_t kBrotliDictionary[122784];
+BROTLI_COMMON_API extern const uint32_t kBrotliDictionaryOffsetsByLength[25];
+BROTLI_COMMON_API extern const uint8_t kBrotliDictionarySizeBitsByLength[25];
 
 #define kBrotliMinDictionaryWordLength 4
 #define kBrotliMaxDictionaryWordLength 24

--- a/dec/decode.c
+++ b/dec/decode.c
@@ -133,7 +133,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode DecodeVarLenUint8(
   uint32_t bits;
   switch (s->substate_decode_uint8) {
     case BROTLI_STATE_DECODE_UINT8_NONE:
-      if (PREDICT_FALSE(!BrotliSafeReadBits(br, 1, &bits))) {
+      if (BROTLI_PREDICT_FALSE(!BrotliSafeReadBits(br, 1, &bits))) {
         return BROTLI_DECODER_NEEDS_MORE_INPUT;
       }
       if (bits == 0) {
@@ -143,7 +143,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode DecodeVarLenUint8(
       /* No break, transit to the next state. */
 
     case BROTLI_STATE_DECODE_UINT8_SHORT:
-      if (PREDICT_FALSE(!BrotliSafeReadBits(br, 3, &bits))) {
+      if (BROTLI_PREDICT_FALSE(!BrotliSafeReadBits(br, 3, &bits))) {
         s->substate_decode_uint8 = BROTLI_STATE_DECODE_UINT8_SHORT;
         return BROTLI_DECODER_NEEDS_MORE_INPUT;
       }
@@ -157,7 +157,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode DecodeVarLenUint8(
       /* No break, transit to the next state. */
 
     case BROTLI_STATE_DECODE_UINT8_LONG:
-      if (PREDICT_FALSE(!BrotliSafeReadBits(br, *value, &bits))) {
+      if (BROTLI_PREDICT_FALSE(!BrotliSafeReadBits(br, *value, &bits))) {
         s->substate_decode_uint8 = BROTLI_STATE_DECODE_UINT8_LONG;
         return BROTLI_DECODER_NEEDS_MORE_INPUT;
       }
@@ -360,7 +360,7 @@ static BROTLI_NOINLINE BROTLI_BOOL SafeDecodeSymbol(
 static BROTLI_INLINE BROTLI_BOOL SafeReadSymbol(
     const HuffmanCode* table, BrotliBitReader* br, uint32_t* result) {
   uint32_t val;
-  if (PREDICT_TRUE(BrotliSafeGetBits(br, 15, &val))) {
+  if (BROTLI_PREDICT_TRUE(BrotliSafeGetBits(br, 15, &val))) {
     *result = DecodeSymbol(val, table, br);
     return BROTLI_TRUE;
   }
@@ -388,7 +388,7 @@ static BROTLI_INLINE uint32_t ReadPreloadedSymbol(const HuffmanCode* table,
                                                   uint32_t* bits,
                                                   uint32_t* value) {
   uint32_t result = *value;
-  if (PREDICT_FALSE(*bits > HUFFMAN_TABLE_BITS)) {
+  if (BROTLI_PREDICT_FALSE(*bits > HUFFMAN_TABLE_BITS)) {
     uint32_t val = BrotliGet16BitsUnmasked(br);
     const HuffmanCode* ext = table + (val & HUFFMAN_TABLE_MASK) + *value;
     uint32_t mask = BitMask((*bits - HUFFMAN_TABLE_BITS));
@@ -425,7 +425,7 @@ static BrotliDecoderErrorCode ReadSimpleHuffmanSymbols(
   uint32_t num_symbols = s->symbol;
   while (i <= num_symbols) {
     uint32_t v;
-    if (PREDICT_FALSE(!BrotliSafeReadBits(br, max_bits, &v))) {
+    if (BROTLI_PREDICT_FALSE(!BrotliSafeReadBits(br, max_bits, &v))) {
       s->sub_loop_counter = i;
       s->substate_huffman = BROTLI_STATE_HUFFMAN_SIMPLE_READ;
       return BROTLI_DECODER_NEEDS_MORE_INPUT;
@@ -631,7 +631,7 @@ static BrotliDecoderErrorCode ReadCodeLengthCodeLengths(BrotliDecoderState* s) {
     const uint8_t code_len_idx = kCodeLengthCodeOrder[i];
     uint32_t ix;
     uint32_t v;
-    if (PREDICT_FALSE(!BrotliSafeGetBits(br, 4, &ix))) {
+    if (BROTLI_PREDICT_FALSE(!BrotliSafeGetBits(br, 4, &ix))) {
       uint32_t available_bits = BrotliGetAvailableBits(br);
       if (available_bits != 0) {
         ix = BrotliGetBitsUnmasked(br) & 0xF;
@@ -1514,7 +1514,7 @@ static BROTLI_INLINE BROTLI_BOOL ReadCommandInternal(
   s->dist_htree_index = s->dist_context_map_slice[s->distance_context];
   *insert_length = v.insert_len_offset;
   if (!safe) {
-    if (PREDICT_FALSE(v.insert_len_extra_bits != 0)) {
+    if (BROTLI_PREDICT_FALSE(v.insert_len_extra_bits != 0)) {
       insert_len_extra = BrotliReadBits(br, v.insert_len_extra_bits);
     }
     copy_length = BrotliReadBits(br, v.copy_len_extra_bits);
@@ -1598,7 +1598,7 @@ CommandBegin:
     result = BROTLI_DECODER_NEEDS_MORE_INPUT;
     goto saveStateAndReturn;
   }
-  if (PREDICT_FALSE(s->block_length[1] == 0)) {
+  if (BROTLI_PREDICT_FALSE(s->block_length[1] == 0)) {
     BROTLI_SAFE(DecodeCommandBlockSwitch(s));
     goto CommandBegin;
   }
@@ -1626,7 +1626,7 @@ CommandInner:
         result = BROTLI_DECODER_NEEDS_MORE_INPUT;
         goto saveStateAndReturn;
       }
-      if (PREDICT_FALSE(s->block_length[0] == 0)) {
+      if (BROTLI_PREDICT_FALSE(s->block_length[0] == 0)) {
         BROTLI_SAFE(DecodeLiteralBlockSwitch(s));
         PreloadSymbol(safe, s->literal_htree, br, &bits, &value);
         if (!s->trivial_literal_context) goto CommandInner;
@@ -1645,7 +1645,7 @@ CommandInner:
       --s->block_length[0];
       BROTLI_LOG_ARRAY_INDEX(s->ringbuffer, pos);
       ++pos;
-      if (PREDICT_FALSE(pos == s->ringbuffer_size)) {
+      if (BROTLI_PREDICT_FALSE(pos == s->ringbuffer_size)) {
         s->state = BROTLI_STATE_COMMAND_INNER_WRITE;
         --i;
         goto saveStateAndReturn;
@@ -1662,7 +1662,7 @@ CommandInner:
         result = BROTLI_DECODER_NEEDS_MORE_INPUT;
         goto saveStateAndReturn;
       }
-      if (PREDICT_FALSE(s->block_length[0] == 0)) {
+      if (BROTLI_PREDICT_FALSE(s->block_length[0] == 0)) {
         BROTLI_SAFE(DecodeLiteralBlockSwitch(s));
         if (s->trivial_literal_context) goto CommandInner;
       }
@@ -1685,7 +1685,7 @@ CommandInner:
       BROTLI_LOG_UINT(s->context_map_slice[context]);
       BROTLI_LOG_ARRAY_INDEX(s->ringbuffer, pos & s->ringbuffer_mask);
       ++pos;
-      if (PREDICT_FALSE(pos == s->ringbuffer_size)) {
+      if (BROTLI_PREDICT_FALSE(pos == s->ringbuffer_size)) {
         s->state = BROTLI_STATE_COMMAND_INNER_WRITE;
         --i;
         goto saveStateAndReturn;
@@ -1693,7 +1693,7 @@ CommandInner:
     } while (--i != 0);
   }
   BROTLI_LOG_UINT(s->meta_block_remaining_len);
-  if (PREDICT_FALSE(s->meta_block_remaining_len <= 0)) {
+  if (BROTLI_PREDICT_FALSE(s->meta_block_remaining_len <= 0)) {
     s->state = BROTLI_STATE_METABLOCK_DONE;
     goto saveStateAndReturn;
   }
@@ -1708,7 +1708,7 @@ CommandPostDecodeLiterals:
     goto postReadDistance;  /* We already have the implicit distance */
   }
   /* Read distance code in the command, unless it was implicitly zero. */
-  if (PREDICT_FALSE(s->block_length[2] == 0)) {
+  if (BROTLI_PREDICT_FALSE(s->block_length[2] == 0)) {
     BROTLI_SAFE(DecodeDistanceBlockSwitch(s));
   }
   BROTLI_SAFE(ReadDistance(s, br));
@@ -1809,7 +1809,7 @@ CommandPostWrapCopy:
       s->ringbuffer[pos] =
           s->ringbuffer[(pos - s->distance_code) & s->ringbuffer_mask];
       ++pos;
-      if (PREDICT_FALSE(--wrap_guard == 0)) {
+      if (BROTLI_PREDICT_FALSE(--wrap_guard == 0)) {
         s->state = BROTLI_STATE_COMMAND_POST_WRITE_2;
         goto saveStateAndReturn;
       }

--- a/enc/backward_references.c
+++ b/enc/backward_references.c
@@ -436,7 +436,7 @@ static void UpdateNodes(const size_t num_bytes,
       if (prev_ix >= cur_ix) {
         continue;
       }
-      if (PREDICT_FALSE(backward > max_distance)) {
+      if (BROTLI_PREDICT_FALSE(backward > max_distance)) {
         continue;
       }
       prev_ix &= ringbuffer_mask;

--- a/enc/brotli_bit_stream.c
+++ b/enc/brotli_bit_stream.c
@@ -456,7 +456,7 @@ void BrotliBuildAndStoreHuffmanTreeFast(MemoryManager* m,
       for (l = length; l != 0;) {
         --l;
         if (histogram[l]) {
-          if (PREDICT_TRUE(histogram[l] >= count_limit)) {
+          if (BROTLI_PREDICT_TRUE(histogram[l] >= count_limit)) {
             InitHuffmanTree(node, histogram[l], -1, (int16_t)l);
           } else {
             InitHuffmanTree(node, count_limit, -1, (int16_t)l);

--- a/enc/compress_fragment.c
+++ b/enc/compress_fragment.c
@@ -502,7 +502,7 @@ static BROTLI_INLINE void BrotliCompressFragmentFastImpl(
   last_distance = -1;
   ip_end = input + block_size;
 
-  if (PREDICT_TRUE(block_size >= kInputMarginBytes)) {
+  if (BROTLI_PREDICT_TRUE(block_size >= kInputMarginBytes)) {
     /* For the last block, we need to keep a 16 bytes margin so that we can be
        sure that all distances are at most window size - 16.
        For all other blocks, we only need to keep a margin of 5 bytes so that
@@ -540,13 +540,13 @@ trawl:
         assert(hash == Hash(next_ip, shift));
         ip = next_ip;
         next_ip = ip + bytes_between_hash_lookups;
-        if (PREDICT_FALSE(next_ip > ip_limit)) {
+        if (BROTLI_PREDICT_FALSE(next_ip > ip_limit)) {
           goto emit_remainder;
         }
         next_hash = Hash(next_ip, shift);
         candidate = ip - last_distance;
         if (IsMatch(ip, candidate)) {
-          if (PREDICT_TRUE(candidate < ip)) {
+          if (BROTLI_PREDICT_TRUE(candidate < ip)) {
             table[hash] = (int)(ip - base_ip);
             break;
           }
@@ -556,7 +556,7 @@ trawl:
         assert(candidate < ip);
 
         table[hash] = (int)(ip - base_ip);
-      } while (PREDICT_TRUE(!IsMatch(ip, candidate)));
+      } while (BROTLI_PREDICT_TRUE(!IsMatch(ip, candidate)));
 
       /* Check copy distance. If candidate is not feasible, continue search.
          Checking is done outside of hot loop to reduce overhead. */
@@ -577,7 +577,7 @@ trawl:
         size_t insert = (size_t)(base - next_emit);
         ip += matched;
         assert(0 == memcmp(base, candidate, matched));
-        if (PREDICT_TRUE(insert < 6210)) {
+        if (BROTLI_PREDICT_TRUE(insert < 6210)) {
           EmitInsertLen(insert, cmd_depth, cmd_bits, cmd_histo,
                         storage_ix, storage);
         } else if (ShouldUseUncompressedMode(metablock_start, next_emit, insert,
@@ -606,7 +606,7 @@ trawl:
                                 storage_ix, storage);
 
         next_emit = ip;
-        if (PREDICT_FALSE(ip >= ip_limit)) {
+        if (BROTLI_PREDICT_FALSE(ip >= ip_limit)) {
           goto emit_remainder;
         }
         /* We could immediately start working at ip now, but to improve
@@ -643,7 +643,7 @@ trawl:
                      cmd_histo, storage_ix, storage);
 
         next_emit = ip;
-        if (PREDICT_FALSE(ip >= ip_limit)) {
+        if (BROTLI_PREDICT_FALSE(ip >= ip_limit)) {
           goto emit_remainder;
         }
         /* We could immediately start working at ip now, but to improve
@@ -691,7 +691,7 @@ trawl:
   /* Emit the remaining bytes as literals. */
   if (next_emit < ip_end) {
     const size_t insert = (size_t)(ip_end - next_emit);
-    if (PREDICT_TRUE(insert < 6210)) {
+    if (BROTLI_PREDICT_TRUE(insert < 6210)) {
       EmitInsertLen(insert, cmd_depth, cmd_bits, cmd_histo,
                     storage_ix, storage);
       EmitLiterals(next_emit, insert, lit_depth, lit_bits, storage_ix, storage);

--- a/enc/compress_fragment_two_pass.c
+++ b/enc/compress_fragment_two_pass.c
@@ -252,7 +252,7 @@ static BROTLI_INLINE void CreateCommands(const uint8_t* input,
   const size_t kInputMarginBytes = BROTLI_WINDOW_GAP;
   const size_t kMinMatchLen = 6;
 
-  if (PREDICT_TRUE(block_size >= kInputMarginBytes)) {
+  if (BROTLI_PREDICT_TRUE(block_size >= kInputMarginBytes)) {
     /* For the last block, we need to keep a 16 bytes margin so that we can be
        sure that all distances are at most window size - 16.
        For all other blocks, we only need to keep a margin of 5 bytes so that
@@ -291,13 +291,13 @@ trawl:
         ip = next_ip;
         assert(hash == Hash(ip, shift));
         next_ip = ip + bytes_between_hash_lookups;
-        if (PREDICT_FALSE(next_ip > ip_limit)) {
+        if (BROTLI_PREDICT_FALSE(next_ip > ip_limit)) {
           goto emit_remainder;
         }
         next_hash = Hash(next_ip, shift);
         candidate = ip - last_distance;
         if (IsMatch(ip, candidate)) {
-          if (PREDICT_TRUE(candidate < ip)) {
+          if (BROTLI_PREDICT_TRUE(candidate < ip)) {
             table[hash] = (int)(ip - base_ip);
             break;
           }
@@ -307,7 +307,7 @@ trawl:
         assert(candidate < ip);
 
         table[hash] = (int)(ip - base_ip);
-      } while (PREDICT_TRUE(!IsMatch(ip, candidate)));
+      } while (BROTLI_PREDICT_TRUE(!IsMatch(ip, candidate)));
 
       /* Check copy distance. If candidate is not feasible, continue search.
          Checking is done outside of hot loop to reduce overhead. */
@@ -341,7 +341,7 @@ trawl:
         EmitCopyLenLastDistance(matched, commands);
 
         next_emit = ip;
-        if (PREDICT_FALSE(ip >= ip_limit)) {
+        if (BROTLI_PREDICT_FALSE(ip >= ip_limit)) {
           goto emit_remainder;
         }
         {
@@ -381,7 +381,7 @@ trawl:
         EmitDistance((uint32_t)last_distance, commands);
 
         next_emit = ip;
-        if (PREDICT_FALSE(ip >= ip_limit)) {
+        if (BROTLI_PREDICT_FALSE(ip >= ip_limit)) {
           goto emit_remainder;
         }
         {

--- a/enc/find_match_length.h
+++ b/enc/find_match_length.h
@@ -24,8 +24,8 @@ static BROTLI_INLINE size_t FindMatchLengthWithLimit(const uint8_t* s1,
                                                      size_t limit) {
   size_t matched = 0;
   size_t limit2 = (limit >> 3) + 1;  /* + 1 is for pre-decrement in while */
-  while (PREDICT_TRUE(--limit2)) {
-    if (PREDICT_FALSE(BROTLI_UNALIGNED_LOAD64(s2) ==
+  while (BROTLI_PREDICT_TRUE(--limit2)) {
+    if (BROTLI_PREDICT_FALSE(BROTLI_UNALIGNED_LOAD64(s2) ==
                       BROTLI_UNALIGNED_LOAD64(s1 + matched))) {
       s2 += 8;
       matched += 8;
@@ -39,7 +39,7 @@ static BROTLI_INLINE size_t FindMatchLengthWithLimit(const uint8_t* s1,
   }
   limit = (limit & 7) + 1;  /* + 1 is for pre-decrement in while */
   while (--limit) {
-    if (PREDICT_TRUE(s1[matched] == *s2)) {
+    if (BROTLI_PREDICT_TRUE(s1[matched] == *s2)) {
       ++s2;
       ++matched;
     } else {

--- a/enc/hash.h
+++ b/enc/hash.h
@@ -432,7 +432,7 @@ static BROTLI_INLINE size_t FN(FindAllMatches)(HashToBinaryTree* self,
   for (i = cur_ix - 1; i > stop && best_len <= 2; --i) {
     size_t prev_ix = i;
     const size_t backward = cur_ix - prev_ix;
-    if (PREDICT_FALSE(backward > max_backward)) {
+    if (BROTLI_PREDICT_FALSE(backward > max_backward)) {
       break;
     }
     prev_ix &= ring_buffer_mask;

--- a/enc/hash_longest_match_inc.h
+++ b/enc/hash_longest_match_inc.h
@@ -156,7 +156,7 @@ static BROTLI_INLINE BROTLI_BOOL FN(FindLongestMatch)(HashLongestMatch* self,
     if (prev_ix >= cur_ix) {
       continue;
     }
-    if (PREDICT_FALSE(backward > max_backward)) {
+    if (BROTLI_PREDICT_FALSE(backward > max_backward)) {
       continue;
     }
     prev_ix &= ring_buffer_mask;
@@ -194,7 +194,7 @@ static BROTLI_INLINE BROTLI_BOOL FN(FindLongestMatch)(HashLongestMatch* self,
     for (i = self->num_[key]; i > down;) {
       size_t prev_ix = bucket[--i & BLOCK_MASK];
       const size_t backward = cur_ix - prev_ix;
-      if (PREDICT_FALSE(backward > max_backward)) {
+      if (BROTLI_PREDICT_FALSE(backward > max_backward)) {
         break;
       }
       prev_ix &= ring_buffer_mask;

--- a/enc/hash_longest_match_quickly_inc.h
+++ b/enc/hash_longest_match_quickly_inc.h
@@ -173,7 +173,7 @@ static BROTLI_INLINE BROTLI_BOOL FN(FindLongestMatch)(
     if (compare_char != data[prev_ix + best_len_in]) {
       return BROTLI_FALSE;
     }
-    if (PREDICT_FALSE(backward == 0 || backward > max_backward)) {
+    if (BROTLI_PREDICT_FALSE(backward == 0 || backward > max_backward)) {
       return BROTLI_FALSE;
     }
     len = FindMatchLengthWithLimit(&data[prev_ix],
@@ -196,7 +196,7 @@ static BROTLI_INLINE BROTLI_BOOL FN(FindLongestMatch)(
       if (compare_char != data[prev_ix + best_len]) {
         continue;
       }
-      if (PREDICT_FALSE(backward == 0 || backward > max_backward)) {
+      if (BROTLI_PREDICT_FALSE(backward == 0 || backward > max_backward)) {
         continue;
       }
       len = FindMatchLengthWithLimit(&data[prev_ix],

--- a/enc/ringbuffer.h
+++ b/enc/ringbuffer.h
@@ -93,7 +93,7 @@ static BROTLI_INLINE void RingBufferInitBuffer(
 static BROTLI_INLINE void RingBufferWriteTail(
     const uint8_t *bytes, size_t n, RingBuffer* rb) {
   const size_t masked_pos = rb->pos_ & rb->mask_;
-  if (PREDICT_FALSE(masked_pos < rb->tail_size_)) {
+  if (BROTLI_PREDICT_FALSE(masked_pos < rb->tail_size_)) {
     /* Just fill the tail buffer with the beginning data. */
     const size_t p = rb->size_ + masked_pos;
     memcpy(&rb->buffer_[p], bytes,
@@ -131,7 +131,7 @@ static BROTLI_INLINE void RingBufferWrite(
     /* The length of the writes is limited so that we do not need to worry
        about a write */
     RingBufferWriteTail(bytes, n, rb);
-    if (PREDICT_TRUE(masked_pos + n <= rb->size_)) {
+    if (BROTLI_PREDICT_TRUE(masked_pos + n <= rb->size_)) {
       /* A single write fits. */
       memcpy(&rb->buffer_[masked_pos], bytes, n);
     } else {

--- a/include/brotli/decode.h
+++ b/include/brotli/decode.h
@@ -9,6 +9,7 @@
 #ifndef BROTLI_DEC_DECODE_H_
 #define BROTLI_DEC_DECODE_H_
 
+#include <brotli/port.h>
 #include <brotli/types.h>
 
 #if defined(__cplusplus) || defined(c_plusplus)
@@ -85,15 +86,15 @@ typedef enum {
    and |free_func| MUST be both zero or both non-zero. In the case they are both
    zero, default memory allocators are used. |opaque| is passed to |alloc_func|
    and |free_func| when they are called. */
-BrotliDecoderState* BrotliDecoderCreateInstance(
+BROTLI_DEC_API BrotliDecoderState* BrotliDecoderCreateInstance(
     brotli_alloc_func alloc_func, brotli_free_func free_func, void* opaque);
 
 /* Deinitializes and frees BrotliDecoderState instance. */
-void BrotliDecoderDestroyInstance(BrotliDecoderState* state);
+BROTLI_DEC_API void BrotliDecoderDestroyInstance(BrotliDecoderState* state);
 
 /* Decompresses the data in |encoded_buffer| into |decoded_buffer|, and sets
    |*decoded_size| to the decompressed length. */
-BrotliDecoderResult BrotliDecoderDecompress(
+BROTLI_DEC_API BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size,
     const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
     size_t* decoded_size,
@@ -115,7 +116,7 @@ BrotliDecoderResult BrotliDecoderDecompress(
 
    Input is never overconsumed, so |next_in| and |available_in| could be passed
    to the next consumer after decoding is complete. */
-BrotliDecoderResult BrotliDecoderDecompressStream(
+BROTLI_DEC_API BrotliDecoderResult BrotliDecoderDecompressStream(
   BrotliDecoderState* s, size_t* available_in, const uint8_t** next_in,
   size_t* available_out, uint8_t** next_out, size_t* total_out);
 
@@ -130,13 +131,14 @@ BrotliDecoderResult BrotliDecoderDecompressStream(
     3) Use BrotliDecoderDecompressStream
     4) Clean up and free state with BrotliDestroyState
 */
-void BrotliDecoderSetCustomDictionary(
+BROTLI_DEC_API void BrotliDecoderSetCustomDictionary(
     BrotliDecoderState* s, size_t size,
     const uint8_t dict[BROTLI_ARRAY_PARAM(size)]);
 
 /* Returns true, if decoder has some unconsumed output.
    Otherwise returns false. */
-BROTLI_BOOL BrotliDecoderHasMoreOutput(const BrotliDecoderState* s);
+BROTLI_DEC_API BROTLI_BOOL BrotliDecoderHasMoreOutput(
+    const BrotliDecoderState* s);
 
 /* Returns pointer to internal output buffer.
    Set |size| to zero, to request all the continous output produced by decoder
@@ -151,11 +153,12 @@ BROTLI_BOOL BrotliDecoderHasMoreOutput(const BrotliDecoderState* s);
    Also this could be useful if there is an output stream that is able to
    consume all the provided data (e.g. when data is saved to file system).
  */
-const uint8_t* BrotliDecoderTakeOutput(BrotliDecoderState* s, size_t* size);
+BROTLI_DEC_API const uint8_t* BrotliDecoderTakeOutput(
+    BrotliDecoderState* s, size_t* size);
 
 /* Returns true, if decoder has already received some input bytes.
    Otherwise returns false. */
-BROTLI_BOOL BrotliDecoderIsUsed(const BrotliDecoderState* s);
+BROTLI_DEC_API BROTLI_BOOL BrotliDecoderIsUsed(const BrotliDecoderState* s);
 
 /* Returns true, if decoder is in a state where we reached the end of the input
    and produced all of the output; returns false otherwise. */
@@ -165,10 +168,10 @@ BROTLI_BOOL BrotliDecoderIsFinished(const BrotliDecoderState* s);
    BROTLI_DECODER_RESULT_ERROR. */
 BrotliDecoderErrorCode BrotliDecoderGetErrorCode(const BrotliDecoderState* s);
 
-const char* BrotliDecoderErrorString(BrotliDecoderErrorCode c);
+BROTLI_DEC_API const char* BrotliDecoderErrorString(BrotliDecoderErrorCode c);
 
 /* Decoder version. Look at BROTLI_VERSION for more information. */
-uint32_t BrotliDecoderVersion(void);
+BROTLI_DEC_API uint32_t BrotliDecoderVersion(void);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 } /* extern "C" */

--- a/include/brotli/encode.h
+++ b/include/brotli/encode.h
@@ -69,22 +69,22 @@ typedef enum BrotliEncoderParameter {
 /* A state can not be reused for multiple brotli streams. */
 typedef struct BrotliEncoderStateStruct BrotliEncoderState;
 
-BROTLI_BOOL BrotliEncoderSetParameter(
+BROTLI_ENC_API BROTLI_BOOL BrotliEncoderSetParameter(
     BrotliEncoderState* state, BrotliEncoderParameter p, uint32_t value);
 
 /* Creates the instance of BrotliEncoderState and initializes it.
    |alloc_func| and |free_func| MUST be both zero or both non-zero. In the case
    they are both zero, default memory allocators are used. |opaque| is passed to
    |alloc_func| and |free_func| when they are called. */
-BrotliEncoderState* BrotliEncoderCreateInstance(brotli_alloc_func alloc_func,
-                                                brotli_free_func free_func,
-                                                void* opaque);
+BROTLI_ENC_API BrotliEncoderState* BrotliEncoderCreateInstance(
+    brotli_alloc_func alloc_func, brotli_free_func free_func, void* opaque);
 
 /* Deinitializes and frees BrotliEncoderState instance. */
-void BrotliEncoderDestroyInstance(BrotliEncoderState* state);
+BROTLI_ENC_API void BrotliEncoderDestroyInstance(BrotliEncoderState* state);
 
 /* The maximum input size that can be processed at once. */
-BROTLI_DEPRECATED size_t BrotliEncoderInputBlockSize(BrotliEncoderState* state);
+BROTLI_DEPRECATED BROTLI_ENC_API size_t BrotliEncoderInputBlockSize(
+    BrotliEncoderState* state);
 
 /* Copies the given input data to the internal ring buffer of the compressor.
    No processing of the data occurs at this time and this function can be
@@ -92,7 +92,7 @@ BROTLI_DEPRECATED size_t BrotliEncoderInputBlockSize(BrotliEncoderState* state);
    accumulated input. At most input_block_size() bytes of input data can be
    copied to the ring buffer, otherwise the next WriteBrotliData() will fail.
  */
-BROTLI_DEPRECATED void BrotliEncoderCopyInputToRingBuffer(
+BROTLI_DEPRECATED BROTLI_ENC_API void BrotliEncoderCopyInputToRingBuffer(
     BrotliEncoderState* state, const size_t input_size,
     const uint8_t* input_buffer);
 
@@ -106,7 +106,7 @@ BROTLI_DEPRECATED void BrotliEncoderCopyInputToRingBuffer(
    use WriteMetadata() to append an empty meta-data block.
    Returns false if the size of the input data is larger than
    input_block_size(). */
-BROTLI_DEPRECATED BROTLI_BOOL BrotliEncoderWriteData(
+BROTLI_DEPRECATED BROTLI_ENC_API BROTLI_BOOL BrotliEncoderWriteData(
     BrotliEncoderState* state, const BROTLI_BOOL is_last,
     const BROTLI_BOOL force_flush, size_t* out_size, uint8_t** output);
 
@@ -115,14 +115,14 @@ BROTLI_DEPRECATED BROTLI_BOOL BrotliEncoderWriteData(
    Not to be confused with the built-in transformable dictionary of Brotli.
    To decode, use BrotliDecoderSetCustomDictionary() of the decoder with the
    same dictionary. */
-void BrotliEncoderSetCustomDictionary(
+BROTLI_ENC_API void BrotliEncoderSetCustomDictionary(
     BrotliEncoderState* state, size_t size,
     const uint8_t dict[BROTLI_ARRAY_PARAM(size)]);
 
 /* Returns buffer size that is large enough to contain BrotliEncoderCompress
    output for any input.
    Returns 0 if result does not fit size_t. */
-size_t BrotliEncoderMaxCompressedSize(size_t input_size);
+BROTLI_ENC_API size_t BrotliEncoderMaxCompressedSize(size_t input_size);
 
 /* Compresses the data in |input_buffer| into |encoded_buffer|, and sets
    |*encoded_size| to the compressed length.
@@ -133,7 +133,7 @@ size_t BrotliEncoderMaxCompressedSize(size_t input_size);
    If BrotliEncoderMaxCompressedSize(|input_size|) is not zero, then
    |*encoded_size| is never set to the bigger value.
    Returns false if there was an error and true otherwise. */
-BROTLI_BOOL BrotliEncoderCompress(
+BROTLI_ENC_API BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
     const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
     size_t* encoded_size,
@@ -177,7 +177,7 @@ BROTLI_BOOL BrotliEncoderCompress(
 
    Returns false if there was an error and true otherwise.
 */
-BROTLI_BOOL BrotliEncoderCompressStream(
+BROTLI_ENC_API BROTLI_BOOL BrotliEncoderCompressStream(
     BrotliEncoderState* s, BrotliEncoderOperation op, size_t* available_in,
     const uint8_t** next_in, size_t* available_out, uint8_t** next_out,
     size_t* total_out);
@@ -186,12 +186,12 @@ BROTLI_BOOL BrotliEncoderCompressStream(
    no more output will be produced.
    Works only with BrotliEncoderCompressStream workflow.
    Returns 1 if stream is finished and 0 otherwise. */
-BROTLI_BOOL BrotliEncoderIsFinished(BrotliEncoderState* s);
+BROTLI_ENC_API BROTLI_BOOL BrotliEncoderIsFinished(BrotliEncoderState* s);
 
 /* Check if encoder has more output bytes in internal buffer.
    Works only with BrotliEncoderCompressStream workflow.
    Returns 1 if has more output (in internal buffer) and 0 otherwise. */
-BROTLI_BOOL BrotliEncoderHasMoreOutput(BrotliEncoderState* s);
+BROTLI_ENC_API BROTLI_BOOL BrotliEncoderHasMoreOutput(BrotliEncoderState* s);
 
 /* Returns pointer to internal output buffer.
    Set |size| to zero, to request all the continous output produced by encoder
@@ -206,11 +206,12 @@ BROTLI_BOOL BrotliEncoderHasMoreOutput(BrotliEncoderState* s);
    Also this could be useful if there is an output stream that is able to
    consume all the provided data (e.g. when data is saved to file system).
  */
-const uint8_t* BrotliEncoderTakeOutput(BrotliEncoderState* s, size_t* size);
+BROTLI_ENC_API const uint8_t* BrotliEncoderTakeOutput(
+    BrotliEncoderState* s, size_t* size);
 
 
 /* Encoder version. Look at BROTLI_VERSION for more information. */
-uint32_t BrotliEncoderVersion(void);
+BROTLI_ENC_API uint32_t BrotliEncoderVersion(void);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }  /* extern "C" */

--- a/include/brotli/port.h
+++ b/include/brotli/port.h
@@ -42,11 +42,12 @@
 #define BROTLI_MODERN_COMPILER 0
 #endif
 
-/* Define "PREDICT_TRUE" and "PREDICT_FALSE" macros for capable compilers.
+/* Define "BROTLI_PREDICT_TRUE" and "BROTLI_PREDICT_FALSE" macros for capable
+   compilers.
 
 To apply compiler hint, enclose the branching condition into macros, like this:
 
-  if (PREDICT_TRUE(zero == 0)) {
+  if (BROTLI_PREDICT_TRUE(zero == 0)) {
     // main execution path
   } else {
     // compiler should place this code outside of main execution path
@@ -54,41 +55,64 @@ To apply compiler hint, enclose the branching condition into macros, like this:
 
 OR:
 
-  if (PREDICT_FALSE(something_rare_or_unexpected_happens)) {
+  if (BROTLI_PREDICT_FALSE(something_rare_or_unexpected_happens)) {
     // compiler should place this code outside of main execution path
   }
 
 */
 #if BROTLI_MODERN_COMPILER || __has_builtin(__builtin_expect)
-#define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
-#define PREDICT_FALSE(x) (__builtin_expect(x, 0))
+#define BROTLI_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
+#define BROTLI_PREDICT_FALSE(x) (__builtin_expect(x, 0))
 #else
-#define PREDICT_FALSE(x) (x)
-#define PREDICT_TRUE(x) (x)
+#define BROTLI_PREDICT_FALSE(x) (x)
+#define BROTLI_PREDICT_TRUE(x) (x)
 #endif
 
 #if BROTLI_MODERN_COMPILER || __has_attribute(always_inline)
-#define ATTRIBUTE_ALWAYS_INLINE __attribute__ ((always_inline))
+#define BROTLI_ATTRIBUTE_ALWAYS_INLINE __attribute__ ((always_inline))
 #else
-#define ATTRIBUTE_ALWAYS_INLINE
+#define BROTLI_ATTRIBUTE_ALWAYS_INLINE
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-#define ATTRIBUTE_VISIBILITY_HIDDEN
+#define BROTLI_ATTRIBUTE_VISIBILITY_HIDDEN
 #elif BROTLI_MODERN_COMPILER || __has_attribute(visibility)
-#define ATTRIBUTE_VISIBILITY_HIDDEN __attribute__ ((visibility ("hidden")))
+#define BROTLI_ATTRIBUTE_VISIBILITY_HIDDEN \
+    __attribute__ ((visibility ("hidden")))
 #else
-#define ATTRIBUTE_VISIBILITY_HIDDEN
+#define BROTLI_ATTRIBUTE_VISIBILITY_HIDDEN
 #endif
 
 #ifndef BROTLI_INTERNAL
-#define BROTLI_INTERNAL ATTRIBUTE_VISIBILITY_HIDDEN
+#define BROTLI_INTERNAL BROTLI_ATTRIBUTE_VISIBILITY_HIDDEN
+#endif
+
+#if defined (_WIN32)
+  #if defined(BROTLICOMMON_SHARED_COMPILATION)
+    #define BROTLI_COMMON_API __declspec(dllexport)
+  #else
+    #define BROTLI_COMMON_API __declspec(dllimport)
+  #endif
+  #if defined(BROTLIDEC_SHARED_COMPILATION)
+    #define BROTLI_DEC_API __declspec(dllexport)
+  #else
+    #define BROTLI_DEC_API __declspec(dllimport)
+  #endif
+  #if defined(BROTLIENC_SHARED_COMPILATION)
+    #define BROTLI_ENC_API __declspec(dllexport)
+  #else
+    #define BROTLI_ENC_API __declspec(dllimport)
+  #endif
+#else /* defined (_WIN32) */
+ #define BROTLI_COMMON_API
+ #define BROTLI_DEC_API
+ #define BROTLI_ENC_API
 #endif
 
 #ifndef _MSC_VER
 #if defined(__cplusplus) || !defined(__STRICT_ANSI__) || \
     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
-#define BROTLI_INLINE inline ATTRIBUTE_ALWAYS_INLINE
+#define BROTLI_INLINE inline BROTLI_ATTRIBUTE_ALWAYS_INLINE
 #else
 #define BROTLI_INLINE
 #endif

--- a/include/brotli/port.h
+++ b/include/brotli/port.h
@@ -87,7 +87,7 @@ OR:
 #define BROTLI_INTERNAL BROTLI_ATTRIBUTE_VISIBILITY_HIDDEN
 #endif
 
-#if defined (_WIN32)
+#if defined(BROTLI_SHARED_COMPILATION) && defined(_WIN32)
   #if defined(BROTLICOMMON_SHARED_COMPILATION)
     #define BROTLI_COMMON_API __declspec(dllexport)
   #else


### PR DESCRIPTION
* Declare `BUILD_SHARED_LIBS` option for CMake
* Define `${LIB}_SHARED_COMPILATION` when compiling shared library
* Define and use `BROTLI_xxx_API`
* Fix remaining unprefixed defines in port.h