### PR TITLE
Update API

### DIFF
--- a/enc/entropy_encode_static.h
+++ b/enc/entropy_encode_static.h
@@ -83,7 +83,7 @@ static const uint32_t kCodeLengthBits[18] = {
 static BROTLI_INLINE void StoreStaticCodeLengthCode(
     size_t* storage_ix, uint8_t* storage) {
   BrotliWriteBits(
-      40, MAKE_UINT64_T(0x0000ffU, 0x55555554U), storage_ix, storage);
+      40, BROTLI_MAKE_UINT64_T(0x0000ffU, 0x55555554U), storage_ix, storage);
 }
 
 static const uint64_t kZeroRepsBits[BROTLI_NUM_COMMAND_SYMBOLS] = {
@@ -516,7 +516,7 @@ static const uint16_t kStaticCommandCodeBits[BROTLI_NUM_COMMAND_SYMBOLS] = {
 static BROTLI_INLINE void StoreStaticCommandHuffmanTree(
     size_t* storage_ix, uint8_t* storage) {
   BrotliWriteBits(
-      56, MAKE_UINT64_T(0x926244U, 0x16307003U), storage_ix, storage);
+      56, BROTLI_MAKE_UINT64_T(0x926244U, 0x16307003U), storage_ix, storage);
   BrotliWriteBits(3, 0x00000000U, storage_ix, storage);
 }
 

--- a/include/brotli/decode.h
+++ b/include/brotli/decode.h
@@ -135,8 +135,8 @@ BROTLI_DEC_API void BrotliDecoderSetCustomDictionary(
     BrotliDecoderState* s, size_t size,
     const uint8_t dict[BROTLI_ARRAY_PARAM(size)]);
 
-/* Returns true, if decoder has some unconsumed output.
-   Otherwise returns false. */
+/* Returns BROTLI_TRUE, if decoder has some unconsumed output.
+   Otherwise returns BROTLI_FALSE. */
 BROTLI_DEC_API BROTLI_BOOL BrotliDecoderHasMoreOutput(
     const BrotliDecoderState* s);
 
@@ -156,12 +156,12 @@ BROTLI_DEC_API BROTLI_BOOL BrotliDecoderHasMoreOutput(
 BROTLI_DEC_API const uint8_t* BrotliDecoderTakeOutput(
     BrotliDecoderState* s, size_t* size);
 
-/* Returns true, if decoder has already received some input bytes.
-   Otherwise returns false. */
+/* Returns BROTLI_TRUE, if decoder has already received some input bytes.
+   Otherwise returns BROTLI_FALSE. */
 BROTLI_DEC_API BROTLI_BOOL BrotliDecoderIsUsed(const BrotliDecoderState* s);
 
-/* Returns true, if decoder is in a state where we reached the end of the input
-   and produced all of the output; returns false otherwise. */
+/* Returns BROTLI_TRUE, if decoder is in a state where we reached the end of the
+   input and produced all of the output; returns BROTLI_FALSE otherwise. */
 BROTLI_BOOL BrotliDecoderIsFinished(const BrotliDecoderState* s);
 
 /* Returns detailed error code after BrotliDecoderDecompressStream returns

--- a/include/brotli/port.h
+++ b/include/brotli/port.h
@@ -88,25 +88,25 @@ OR:
 #endif
 
 #if defined(BROTLI_SHARED_COMPILATION) && defined(_WIN32)
-  #if defined(BROTLICOMMON_SHARED_COMPILATION)
-    #define BROTLI_COMMON_API __declspec(dllexport)
-  #else
-    #define BROTLI_COMMON_API __declspec(dllimport)
-  #endif
-  #if defined(BROTLIDEC_SHARED_COMPILATION)
-    #define BROTLI_DEC_API __declspec(dllexport)
-  #else
-    #define BROTLI_DEC_API __declspec(dllimport)
-  #endif
-  #if defined(BROTLIENC_SHARED_COMPILATION)
-    #define BROTLI_ENC_API __declspec(dllexport)
-  #else
-    #define BROTLI_ENC_API __declspec(dllimport)
-  #endif
-#else /* defined (_WIN32) */
- #define BROTLI_COMMON_API
- #define BROTLI_DEC_API
- #define BROTLI_ENC_API
+#if defined(BROTLICOMMON_SHARED_COMPILATION)
+#define BROTLI_COMMON_API __declspec(dllexport)
+#else
+#define BROTLI_COMMON_API __declspec(dllimport)
+#endif  /* BROTLICOMMON_SHARED_COMPILATION */
+#if defined(BROTLIDEC_SHARED_COMPILATION)
+#define BROTLI_DEC_API __declspec(dllexport)
+#else
+#define BROTLI_DEC_API __declspec(dllimport)
+#endif  /* BROTLIDEC_SHARED_COMPILATION */
+#if defined(BROTLIENC_SHARED_COMPILATION)
+#define BROTLI_ENC_API __declspec(dllexport)
+#else
+#define BROTLI_ENC_API __declspec(dllimport)
+#endif  /* BROTLIENC_SHARED_COMPILATION */
+#else  /* BROTLI_SHARED_COMPILATION && _WIN32 */
+#define BROTLI_COMMON_API
+#define BROTLI_DEC_API
+#define BROTLI_ENC_API
 #endif
 
 #ifndef _MSC_VER

--- a/include/brotli/types.h
+++ b/include/brotli/types.h
@@ -24,23 +24,18 @@ typedef __int64 int64_t;
 #include <stdint.h>
 #endif  /* defined(_MSC_VER) && (_MSC_VER < 1600) */
 
-#if (!defined(_MSC_VER) || (_MSC_VER >= 1800)) && \
-    (defined(__cplusplus) || \
-        (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L))
-#include <stdbool.h>
-#define BROTLI_BOOL bool
-#define BROTLI_TRUE true
-#define BROTLI_FALSE false
-#define TO_BROTLI_BOOL(X) (!!(X))
-#else
-typedef enum {
-  BROTLI_FALSE = 0,
-  BROTLI_TRUE = !BROTLI_FALSE
-} BROTLI_BOOL;
+/* BROTLI_BOOL is a portable "bool" replacement. For input parameters it is
+   preferrable either use BROTLI_TRUE and BROTLI_FALSE macros, or convert
+   boolean expression with TO_BROTLI_BOOL macros.
+   Return values should not be tested for equality with "true", "false",
+   "BROTLI_TRUE", "BROTLI_FALSE", but rather be evaluated, for example:
+   `if (foo(enc) && !bar(dec) { bool x = !!baz(enc); }` */
+#define BROTLI_BOOL int
+#define BROTLI_TRUE 1
+#define BROTLI_FALSE 0
 #define TO_BROTLI_BOOL(X) (!!(X) ? BROTLI_TRUE : BROTLI_FALSE)
-#endif
 
-#define MAKE_UINT64_T(high, low) ((((uint64_t)(high)) << 32) | low)
+#define BROTLI_MAKE_UINT64_T(high, low) ((((uint64_t)(high)) << 32) | low)
 
 #define BROTLI_UINT32_MAX (~((uint32_t)0))
 #define BROTLI_SIZE_MAX (~((size_t)0))


### PR DESCRIPTION
 * explicitly define `BROTLI_BOOL` to be `int`
 * add `BROTLI_` prefix to `MAKE_UINT64_T` macros
 * replace `true`/`false`/`1`/`0` mentions with `BROTLI_TRUE`/`FALSE`
 * add `BrotliEncoderSetParameter` documentation
 * add explicit caution to `BrotliEncoderMaxCompressedSize`
 * fix formatting in `port.h`