### PR TITLE
Python: Use "build" instead of "build_ext" in scripts

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -39,7 +39,7 @@ case "$1" in
 		if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
 			source venv/bin/activate
 		fi
-		python setup.py build_ext test
+		python setup.py build test
 		;;
 	esac
 	;;

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [Premake5](https://premake.github.io/)
 
 The basic commands to build, test, and install the Python module are:
 
-    $ python setup.py build_ext test
+    $ python setup.py build test
     $ python setup.py install
 
 See the [Python readme](python/README.md) for more details.

--- a/python/README.md
+++ b/python/README.md
@@ -7,7 +7,7 @@ This directory contains the code for the Python `brotli` module,
 To build the module, execute the following from the root project
 directory:
 
-    $ python setup.py build_ext
+    $ python setup.py build
 
 To test the module, execute the following from the root project
 directory:


### PR DESCRIPTION
---

_edited Oct 28: see updated commit description and in the thread below_
