### PR TITLE
Only use __builtin_clz on GCC >= 3.4

### DIFF
--- a/enc/fast_log.h
+++ b/enc/fast_log.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 static BROTLI_INLINE uint32_t Log2FloorNonZero(size_t n) {
-#ifdef __GNUC__
+#if defined(__GNUC__) && (__GNUC__ > 3 || __GNUC__ == 3 && __GNUC_MINOR__ > 3)
   return 31u ^ (uint32_t)__builtin_clz((uint32_t)n);
 #else
   uint32_t result = 0;


### PR DESCRIPTION
Haiku at least still requires GCC 2 for system components.