### PR TITLE
Haiku: force undefine INFINITY for GCC2 as it's not const

### DIFF
--- a/enc/backward_references.c
+++ b/enc/backward_references.c
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+#if defined(__HAIKU__) && __GNUC__ < 3
+#undef INFINITY
+#endif
+
 #ifdef INFINITY
 static const float kInfinity = INFINITY;
 #else


### PR DESCRIPTION
It's defined as a non-const inline union...
cf. [our current math.h](http://cgit.haiku-os.org/haiku/tree/headers/posix/math.h#n68)
I'm open to a cleaner solution. Maybe we should make it const, not sure though...