### PR TITLE
Blacklist PGI from using conformant array parameters.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -21,6 +21,13 @@ case "$1" in
 			;;
 		esac
 		;;
+	    "linux")
+		case "${CC}" in
+		    "pgcc")
+			wget -q -O /dev/stdout 'https://raw.githubusercontent.com/nemequ/pgi-travis/master/install-pgi.sh' | /bin/sh
+			;;
+		esac
+		;;
 	esac
 	;;
     "script")

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,12 @@ matrix:
           - clang-3.5
 
     ###
+    ## PGI Community Edition on Linux
+    ###
+    - os: linux
+      env: BUILD_SYSTEM=cmake C_COMPILER=pgcc CXX_COMPILER=pgc++
+
+    ###
     ## Python build on Linux
     ###
     - os: linux

--- a/include/brotli/types.h
+++ b/include/brotli/types.h
@@ -81,7 +81,7 @@ typedef void* (*brotli_alloc_func)(void* opaque, size_t size);
 typedef void (*brotli_free_func)(void* opaque, void* address);
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-    !defined(__cplusplus)
+    !defined(__cplusplus) && !defined(__PGI)
 #define BROTLI_ARRAY_PARAM(L) L
 #else
 #define BROTLI_ARRAY_PARAM(L)


### PR DESCRIPTION
There is a bug in pgcc with conformant array parameters where the
length argument is a pointer which triggers a compiler error
(PGC-S-0094, to be specific).  The issue has been reported to PGI and
is being tracked internally as TPR 23778.  For more information, see

  https://www.pgroup.com/userforum/viewtopic.php?t=5501