### PR TITLE
Fix compilation issue with BROTLI_ALLOC macro using GCC 7

### DIFF
--- a/c/enc/memory.h
+++ b/c/enc/memory.h
@@ -40,7 +40,7 @@ BROTLI_INTERNAL void BrotliInitMemoryManager(
 
 BROTLI_INTERNAL void* BrotliAllocate(MemoryManager* m, size_t n);
 #define BROTLI_ALLOC(M, T, N)                               \
-  ((N) ? ((T*)BrotliAllocate((M), (N) * sizeof(T))) : NULL)
+  ((N) > 0 ? ((T*)BrotliAllocate((M), (N) * sizeof(T))) : NULL)
 
 BROTLI_INTERNAL void BrotliFree(MemoryManager* m, void* p);
 #define BROTLI_FREE(M, P) { \


### PR DESCRIPTION
Fixes #561.
The issue is with GCC 7 that adds a check `-Wint-in-bool-context`.
Maybe you'd prefer to disable this check instead?

(Note: I haven't signed the CLA yet.)