### PR TITLE
Fix missing symbols errors in libbrotlienc and dec

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,8 +23,10 @@ libbrotlicommon_la_SOURCES = $(BROTLI_COMMON_C) $(BROTLI_COMMON_H)
 libbrotlicommon_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLI_VERSION_INFO) $(LDFLAGS)
 libbrotlidec_la_SOURCES = $(BROTLI_DEC_C) $(BROTLI_DEC_H)
 libbrotlidec_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLI_VERSION_INFO) $(LDFLAGS)
+libbrotlidec_la_LIBADD = libbrotlicommon.la -lm
 libbrotlienc_la_SOURCES = $(BROTLI_ENC_C) $(BROTLI_ENC_H)
 libbrotlienc_la_LDFLAGS = $(AM_LDFLAGS) $(LIBBROTLI_VERSION_INFO) $(LDFLAGS)
+libbrotlienc_la_LIBADD = libbrotlicommon.la -lm
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = \


### PR DESCRIPTION
When using autotools to build the binary and libraries, the resulting libraries don't link `brotlicommon` or `m`.
This was detected when building cURL 7.57.0 which has now has brotli support. During configure it was failing
```
checking run-time libs availability... failed
configure: error: one or more libs available at link-time are not available run-time. Libs used at link-time: -lbrotlidec -lz -L/usr/local/lib
```
inspection of config.log showed missing symbols from libbrotlicommon as the cause.

This patch results in the encryption and decryption libs to be properly linked against libbrotlicommon and libm.
See also https://bugs.freebsd.org/223966