### PR TITLE
Use MSVC intrinsics in Log2FloorNonZero and FindMatchLengthWithLimit

### DIFF
--- a/c/enc/fast_log.h
+++ b/c/enc/fast_log.h
@@ -19,10 +19,8 @@ extern "C" {
 #endif
 
 static BROTLI_INLINE uint32_t Log2FloorNonZero(size_t n) {
-  /* TODO: generalize and move to platform.h */
-#if BROTLI_GNUC_HAS_BUILTIN(__builtin_clz, 3, 4, 0) || \
-    BROTLI_INTEL_VERSION_CHECK(16, 0, 0)
-  return 31u ^ (uint32_t)__builtin_clz((uint32_t)n);
+#if defined(BROTLI_BSR32)
+  return BROTLI_BSR32((uint32_t)n);
 #else
   uint32_t result = 0;
   while (n >>= 1) result++;

--- a/c/enc/find_match_length.h
+++ b/c/enc/find_match_length.h
@@ -17,8 +17,7 @@ extern "C" {
 #endif
 
 /* Separate implementation for little-endian 64-bit targets, for speed. */
-#if defined(__GNUC__) && defined(_LP64) && defined(BROTLI_LITTLE_ENDIAN)
-
+#if defined(BROTLI_TZCNT64) && BROTLI_64_BITS && BROTLI_LITTLE_ENDIAN
 static BROTLI_INLINE size_t FindMatchLengthWithLimit(const uint8_t* s1,
                                                      const uint8_t* s2,
                                                      size_t limit) {
@@ -32,7 +31,7 @@ static BROTLI_INLINE size_t FindMatchLengthWithLimit(const uint8_t* s1,
     } else {
       uint64_t x = BROTLI_UNALIGNED_LOAD64LE(s2) ^
           BROTLI_UNALIGNED_LOAD64LE(s1 + matched);
-      size_t matching_bits = (size_t)__builtin_ctzll(x);
+      size_t matching_bits = (size_t)BROTLI_TZCNT64(x);
       matched += matching_bits >> 3;
       return matched;
     }


### PR DESCRIPTION
This PR finishes off the work started in https://github.com/google/brotli/pull/618

Switched compiler intrinsic code to use more generic switches and added MSVC-specific versions of the clz and ctz calls where the GCC __builtin functions are used.

Preliminary testing shows an almost 10% speed improvement for encoding on Windows x64.
