### PR TITLE
Update

### DIFF
--- a/c/common/transform.h
+++ b/c/common/transform.h
@@ -1,4 +1,4 @@
-/* transforms is a part of ABI, nut not API.
+/* transforms is a part of ABI, but not API.
 
    It means that there are some functions that are supposed to be in "common"
    library, but header itself is not placed into include/brotli. This way,

--- a/c/common/version.h
+++ b/c/common/version.h
@@ -14,13 +14,13 @@
    BrotliEncoderVersion methods. */
 
 /* Semantic version, calculated as (MAJOR << 24) | (MINOR << 12) | PATCH */
-#define BROTLI_VERSION 0x1000002
+#define BROTLI_VERSION 0x1000003
 
 /* This macro is used by build system to produce Libtool-friendly soname. See
    https://www.gnu.org/software/libtool/manual/html_node/Libtool-versioning.html
  */
 
 /* ABI version, calculated as (CURRENT << 24) | (REVISION << 12) | AGE */
-#define BROTLI_ABI_VERSION 0x1002000
+#define BROTLI_ABI_VERSION 0x1003000
 
 #endif  /* BROTLI_COMMON_VERSION_H_ */

--- a/c/enc/backward_references_inc.h
+++ b/c/enc/backward_references_inc.h
@@ -89,8 +89,8 @@ static BROTLI_NOINLINE void EXPORT_FN(CreateBackwardReferences)(
           dist_cache[0] = (int)sr.distance;
           FN(PrepareDistanceCache)(hasher, dist_cache);
         }
-        InitCommand(commands++, insert_length, sr.len, sr.len_code_delta,
-            distance_code);
+        InitCommand(commands++, &params->dist, insert_length,
+            sr.len, sr.len_code_delta, distance_code);
       }
       *num_literals += insert_length;
       insert_length = 0;

--- a/java/org/brotli/wrapper/dec/BrotliDecoderChannel.java
+++ b/java/org/brotli/wrapper/dec/BrotliDecoderChannel.java
@@ -58,8 +58,8 @@ public class BrotliDecoderChannel extends Decoder implements ReadableByteChannel
       int result = 0;
       while (dst.hasRemaining()) {
         int outputSize = decode();
-        if (outputSize == -1) {
-          return result == 0 ? -1 : result;
+        if (outputSize <= 0) {
+          return result == 0 ? outputSize : result;
         }
         result += consume(dst);
       }

--- a/research/BUILD
+++ b/research/BUILD
@@ -35,3 +35,10 @@ cc_binary(
         ":sieve",
     ],
 )
+
+cc_binary(
+    name = "brotli_decoder",
+    srcs = ["brotli_decoder.c"],
+    linkstatic = 1,
+    deps = ["//:brotlidec"],
+)

--- a/research/brotli_decoder.c
+++ b/research/brotli_decoder.c
@@ -1,0 +1,93 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+   Distributed under MIT license.
+   See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <brotli/decode.h>
+
+#define BUFFER_SIZE (1u << 20)
+
+typedef struct Context {
+  FILE* fin;
+  FILE* fout;
+  uint8_t* input_buffer;
+  uint8_t* output_buffer;
+  BrotliDecoderState* decoder;
+} Context;
+
+void init(Context* ctx) {
+  ctx->fin = 0;
+  ctx->fout = 0;
+  ctx->input_buffer = 0;
+  ctx->output_buffer = 0;
+  ctx->decoder = 0;
+}
+
+void cleanup(Context* ctx) {
+  if (ctx->decoder) BrotliDecoderDestroyInstance(ctx->decoder);
+  if (ctx->output_buffer) free(ctx->output_buffer);
+  if (ctx->input_buffer) free(ctx->input_buffer);
+  if (ctx->fout) fclose(ctx->fout);
+  if (ctx->fin) fclose(ctx->fin);
+}
+
+void fail(Context* ctx, const char* message) {
+  fprintf(stderr, "%s\n", message);
+  exit(1);
+}
+
+int main(int argc, char** argv) {
+  Context ctx;
+  BrotliDecoderResult result = BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT;
+  size_t available_in;
+  const uint8_t* next_in;
+  size_t available_out = BUFFER_SIZE;
+  uint8_t* next_out;
+  init(&ctx);
+
+  ctx.fin = fdopen(STDIN_FILENO, "rb");
+  if (!ctx.fin) fail(&ctx, "can't open input file");
+  ctx.fout = fdopen(STDOUT_FILENO, "wb");
+  if (!ctx.fout) fail(&ctx, "can't open output file");
+  ctx.input_buffer = (uint8_t*)malloc(BUFFER_SIZE);
+  if (!ctx.input_buffer) fail(&ctx, "out of memory / input buffer");
+  ctx.output_buffer = (uint8_t*)malloc(BUFFER_SIZE);
+  if (!ctx.output_buffer) fail(&ctx, "out of memory / output buffer");
+  ctx.decoder = BrotliDecoderCreateInstance(0, 0, 0);
+  if (!ctx.decoder) fail(&ctx, "out of memory / decoder");
+  BrotliDecoderSetParameter(ctx.decoder, BROTLI_DECODER_PARAM_LARGE_WINDOW, 1);
+
+  next_out = ctx.output_buffer;
+  while (1) {
+    if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT) {
+      if (feof(ctx.fin)) break;
+      available_in = fread(ctx.input_buffer, 1, BUFFER_SIZE, ctx.fin);
+      next_in = ctx.input_buffer;
+      if (ferror(ctx.fin)) break;
+    } else if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+      fwrite(ctx.output_buffer, 1, BUFFER_SIZE, ctx.fout);
+      if (ferror(ctx.fout)) break;
+      available_out = BUFFER_SIZE;
+      next_out = ctx.output_buffer;
+    } else {
+      break;
+    }
+    result = BrotliDecoderDecompressStream(
+        ctx.decoder, &available_in, &next_in, &available_out, &next_out, 0);
+  }
+  if (next_out != ctx.output_buffer) {
+    fwrite(ctx.output_buffer, 1, next_out - ctx.output_buffer, ctx.fout);
+  }
+  if ((result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) || ferror(ctx.fout)) {
+    fail(&ctx, "failed to write output");
+  } else if (result != BROTLI_DECODER_RESULT_SUCCESS) {
+    fail(&ctx, "corrupt input");
+  }
+  cleanup(&ctx);
+  return 0;
+}


### PR DESCRIPTION
* make the zopflification aware of `NDIRECT`, `NPOSTFIX` (better compression in `font` mode)
 * add small and simple decoder tool
 * fix typo
 * Java: wrapper: make decoder channel more async-friendly

Ramp up version to 1.0.3 / 1.0.3