### PR TITLE
Update README.md - Add mention of Dart native bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,5 @@ JavaScript port of brotli [decoder](https://github.com/devongovett/brotli.js). C
 Hand ported [decoder / encoder](https://github.com/dominikhlbg/BrotliHaxe) in haxe by Dominik Homberger. Output source code: JavaScript, PHP, Python, Java and C#
 
 7Zip [plugin](https://github.com/mcmilk/7-Zip-Zstd)
+
+Dart [native bindings](https://github.com/thosakwe/brotli)


### PR DESCRIPTION
I was able to use the Dart SDK's native extension support to embed Brotli within the Dart VM. I feel that it might be beneficial to mention this in the README: https://github.com/thosakwe/brotli