### PR TITLE
sources: Fix missing params header

### DIFF
--- a/scripts/sources.lst
+++ b/scripts/sources.lst
@@ -81,6 +81,7 @@ BROTLI_ENC_H = \
   c/enc/memory.h \
   c/enc/metablock.h \
   c/enc/metablock_inc.h \
+  c/enc/params.h \
   c/enc/prefix.h \
   c/enc/quality.h \
   c/enc/ringbuffer.h \


### PR DESCRIPTION
Without the params header being listed we can't generate a working dist
tarball using autotools since it requires all of the sources be
explicitly specified.