### PR TITLE
Tell CMake to not check for a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # support 2.8.7.
 cmake_minimum_required(VERSION 2.8.6)
 
-project(brotli)
+project(brotli C)
 
 # If Brotli is being bundled in another project, we don't want to
 # install anything.  However, we want to let people override this, so


### PR DESCRIPTION
By default CMake checks both for C and C++ compilers, while the latter is not needed. Setting the list of languages to just `C` in the call to `project()` removes the unneeded check.