### PR TITLE
CMake: Allow using BUILD_SHARED_LIBS to choose static/shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ cmake_minimum_required(VERSION 2.8.6)
 cmake_policy(SET CMP0048 NEW)
 project(brotli C)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to Release as none was specified.")
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
@@ -136,10 +138,6 @@ set(BROTLI_LIBRARIES_CORE brotlienc brotlidec brotlicommon)
 set(BROTLI_LIBRARIES ${BROTLI_LIBRARIES_CORE} ${LIBM_LIBRARY})
 mark_as_advanced(BROTLI_LIBRARIES)
 
-set(BROTLI_LIBRARIES_CORE_STATIC brotlienc-static brotlidec-static brotlicommon-static)
-set(BROTLI_LIBRARIES_STATIC ${BROTLI_LIBRARIES_CORE_STATIC} ${LIBM_LIBRARY})
-mark_as_advanced(BROTLI_LIBRARIES_STATIC)
-
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   add_definitions(-DOS_LINUX)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
@@ -162,29 +160,25 @@ transform_sources_list("scripts/sources.lst" "${CMAKE_CURRENT_BINARY_DIR}/source
 include("${CMAKE_CURRENT_BINARY_DIR}/sources.lst.cmake")
 
 if(BROTLI_EMSCRIPTEN)
-  set(BROTLI_SHARED_LIBS "")
-else()
-  set(BROTLI_SHARED_LIBS brotlicommon brotlidec brotlienc)
-  add_library(brotlicommon SHARED ${BROTLI_COMMON_C})
-  add_library(brotlidec SHARED ${BROTLI_DEC_C})
-  add_library(brotlienc SHARED ${BROTLI_ENC_C})
+  set(BUILD_SHARED_LIBS OFF)
 endif()
 
-set(BROTLI_STATIC_LIBS brotlicommon-static brotlidec-static brotlienc-static)
-add_library(brotlicommon-static STATIC ${BROTLI_COMMON_C})
-add_library(brotlidec-static STATIC ${BROTLI_DEC_C})
-add_library(brotlienc-static STATIC ${BROTLI_ENC_C})
+add_library(brotlicommon ${BROTLI_COMMON_C})
+add_library(brotlidec ${BROTLI_DEC_C})
+add_library(brotlienc ${BROTLI_ENC_C})
 
 # Older CMake versions does not understand INCLUDE_DIRECTORIES property.
 include_directories(${BROTLI_INCLUDE_DIRS})
 
-foreach(lib IN LISTS BROTLI_SHARED_LIBS)
-  target_compile_definitions(${lib} PUBLIC "BROTLI_SHARED_COMPILATION" )
-  string(TOUPPER "${lib}" LIB)
-  set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION")
-endforeach()
+if(BUILD_SHARED_LIBS)
+  foreach(lib ${BROTLI_LIBRARIES_CORE})
+    target_compile_definitions(${lib} PUBLIC "BROTLI_SHARED_COMPILATION" )
+    string(TOUPPER "${lib}" LIB)
+    set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION")
+  endforeach()
+endif()
 
-foreach(lib IN LISTS BROTLI_SHARED_LIBS BROTLI_STATIC_LIBS)
+foreach(lib ${BROTLI_LIBRARIES_CORE})
   target_link_libraries(${lib} ${LIBM_LIBRARY})
   set_property(TARGET ${lib} APPEND PROPERTY INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIRS})
   set_target_properties(${lib} PROPERTIES
@@ -201,9 +195,6 @@ target_link_libraries(brotlidec brotlicommon)
 target_link_libraries(brotlienc brotlicommon)
 endif()
 
-target_link_libraries(brotlidec-static brotlicommon-static)
-target_link_libraries(brotlienc-static brotlicommon-static)
-
 # For projects stuck on older versions of CMake, this will set the
 # BROTLI_INCLUDE_DIRS and BROTLI_LIBRARIES variables so they still
 # have a relatively easy way to use Brotli:
@@ -217,7 +208,7 @@ endif()
 
 # Build the brotli executable
 add_executable(brotli ${BROTLI_CLI_C})
-target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
+target_link_libraries(brotli ${BROTLI_LIBRARIES})
 
 # Installation
 if(NOT BROTLI_BUNDLED_MODE)
@@ -234,13 +225,6 @@ if(NOT BROTLI_BUNDLED_MODE)
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
     )
   endif()  # BROTLI_EMSCRIPTEN
-
-  install(
-    TARGETS ${BROTLI_LIBRARIES_CORE_STATIC}
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  )
 
   install(
     DIRECTORY ${BROTLI_INCLUDE_DIRS}/brotli

--- a/c/fuzz/test_fuzzer.sh
+++ b/c/fuzz/test_fuzzer.sh
@@ -13,12 +13,12 @@ mkdir bin
 cd bin
 
 cmake $BROTLI -DCMAKE_C_COMPILER="$CC" \
-    -DBUILD_TESTING=OFF -DENABLE_SANITIZER=address
-make -j$(nproc) brotlidec-static
+    -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DENABLE_SANITIZER=address
+make -j$(nproc) brotlidec
 
 ${CC} -o run_decode_fuzzer -std=c99 -fsanitize=address -I$SRC/include \
     $SRC/fuzz/decode_fuzzer.c $SRC/fuzz/run_decode_fuzzer.c \
-    ./libbrotlidec-static.a ./libbrotlicommon-static.a
+    ./libbrotlidec.a ./libbrotlicommon.a
 
 mkdir decode_corpora
 unzip $BROTLI/java/org/brotli/integration/fuzz_data.zip -d decode_corpora


### PR DESCRIPTION
By convention projects using CMake which can build either static or shared libraries use a `BUILD_SHARED_LIBS` flag to allow selecting between both: the `add_library()` command automatically switches between both using this variable when the library kind is not passed to `add_library()`. It is also usual to expose the `BUILD_SHARED_LIBS` as an user-facing setting with the `option()` command.

This way, the following will both work as expected:

```
   % cmake -DBUILD_SHARED_LIBS=OFF ...
   % cmake -DBUILS_SHARED_LIBS=ON ...
```

This is helpful for distributions which need (or want) to build only static libraries.

----

The above being said, I understand that there might be some reason why it is desirable that both kinds of libraries are always built. If that is the case, let me know and I'll try to come up with some other way of allowing to only build static libraries, and installing them in a way that other projects trying to link with `-lbrotli*` (and/or using `pkg-config`) will find the static libraries.  