### PR TITLE
Fix MSVC compilation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -41,6 +41,12 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "msvc",
+    values = {"compiler": "msvc-cl"},
+    visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "copy_link_jni_header",
     srcs = ["@openjdk_linux//:jni_h"],
@@ -73,19 +79,22 @@ cc_library(
 
 # <<< JNI headers
 
-STRICT_C_OPTIONS = [
-    "--pedantic-errors",
-    "-Wall",
-    "-Wconversion",
-    "-Werror",
-    "-Wextra",
-    "-Wlong-long",
-    "-Wmissing-declarations",
-    "-Wmissing-prototypes",
-    "-Wno-strict-aliasing",
-    "-Wshadow",
-    "-Wsign-compare",
-]
+STRICT_C_OPTIONS = select({
+    ":msvc": [],
+    "//conditions:default": [
+        "--pedantic-errors",
+        "-Wall",
+        "-Wconversion",
+        "-Werror",
+        "-Wextra",
+        "-Wlong-long",
+        "-Wmissing-declarations",
+        "-Wmissing-prototypes",
+        "-Wno-strict-aliasing",
+        "-Wshadow",
+        "-Wsign-compare",
+    ],
+})
 
 filegroup(
     name = "public_headers",

--- a/c/enc/command.h
+++ b/c/enc/command.h
@@ -145,11 +145,11 @@ static BROTLI_INLINE void InitInsertCommand(Command* self, size_t insertlen) {
 
 static BROTLI_INLINE uint32_t CommandRestoreDistanceCode(
     const Command* self, const BrotliDistanceParams* dist) {
-  if ((self->dist_prefix_ & 0x3FF) <
+  if ((self->dist_prefix_ & 0x3FFu) <
       BROTLI_NUM_DISTANCE_SHORT_CODES + dist->num_direct_distance_codes) {
-    return self->dist_prefix_ & 0x3FF;
+    return self->dist_prefix_ & 0x3FFu;
   } else {
-    uint32_t dcode = self->dist_prefix_ & 0x3FF;
+    uint32_t dcode = self->dist_prefix_ & 0x3FFu;
     uint32_t nbits = self->dist_prefix_ >> 10;
     uint32_t extra = self->dist_extra_;
     uint32_t postfix_mask = (1U << dist->distance_postfix_bits) - 1U;


### PR DESCRIPTION
 * tell bazel not to pass strict options to a fancy compiler
 * fix signed-unsigned comparison warning found by MSVC