### PR TITLE
appveyor: fix issue self-upgradig pip to v10

### DIFF
--- a/scripts/appveyor.yml
+++ b/scripts/appveyor.yml
@@ -31,7 +31,7 @@ environment:
 install:
 - IF "%BUILD_SYSTEM%"=="Python" (
     SET "PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%" &&
-    pip install --disable-pip-version-check --user --upgrade pip &&
+    python -m pip install --upgrade pip &&
     pip install --upgrade setuptools
   )
 - IF "%BUILD_SYSTEM%"=="make" (


### PR DESCRIPTION
Installing with `--user` option will leave the old pip.exe script in the $PATH, but then running the latter fails because pip 10 moved 'main' to internal modules.

The fix is to force overwriting the old pip.exe by installing globally without `--user` option.

https://github.com/pypa/pip/issues/5240#issuecomment-382989420