### PR TITLE
Update

### DIFF
--- a/c/common/transform.c
+++ b/c/common/transform.c
@@ -4,7 +4,6 @@
    See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 */
 
-#include "./platform.h"
 #include "./transform.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
@@ -192,7 +191,7 @@ static int ToUpperCase(uint8_t* p) {
 }
 
 int BrotliTransformDictionaryWord(uint8_t* dst, const uint8_t* word, int len,
-    const BrotliTransforms* BROTLI_RESTRICT transforms, int transfom_idx) {
+    const BrotliTransforms* transforms, int transfom_idx) {
   int idx = 0;
   const uint8_t* prefix = BROTLI_TRANSFORM_PREFIX(transforms, transfom_idx);
   uint8_t type = BROTLI_TRANSFORM_TYPE(transforms, transfom_idx);

--- a/c/common/transform.h
+++ b/c/common/transform.h
@@ -71,7 +71,7 @@ BROTLI_COMMON_API const BrotliTransforms* BrotliGetTransforms(void);
 
 BROTLI_COMMON_API int BrotliTransformDictionaryWord(
     uint8_t* dst, const uint8_t* word, int len,
-    const BrotliTransforms* BROTLI_RESTRICT transforms, int transform_idx);
+    const BrotliTransforms* transforms, int transform_idx);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }  /* extern "C" */

--- a/c/dec/bit_reader.h
+++ b/c/dec/bit_reader.h
@@ -238,7 +238,7 @@ static BROTLI_INLINE void BrotliTakeBits(
   BrotliBitReader* const br, uint32_t n_bits, uint32_t* val) {
   *val = (uint32_t)BrotliGetBitsUnmasked(br) & BitMask(n_bits);
   BROTLI_LOG(("[BrotliReadBits]  %d %d %d val: %6x\n",
-      (int)br->avail_in, (int)br->bit_pos_, n_bits, (int)*val));
+      (int)br->avail_in, (int)br->bit_pos_, (int)n_bits, (int)*val));
   BrotliDropBits(br, n_bits);
 }
 

--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -516,7 +516,8 @@ static BROTLI_INLINE void ProcessSingleCodeLength(uint32_t code_len,
     *prev_code_len = code_len;
     *space -= 32768U >> code_len;
     code_length_histo[code_len]++;
-    BROTLI_LOG(("[ReadHuffmanCode] code_length[%d] = %d\n", *symbol, code_len));
+    BROTLI_LOG(("[ReadHuffmanCode] code_length[%d] = %d\n",
+        (int)*symbol, (int)code_len));
   }
   (*symbol)++;
 }
@@ -561,7 +562,7 @@ static BROTLI_INLINE void ProcessRepeatedCodeLength(uint32_t code_len,
     return;
   }
   BROTLI_LOG(("[ReadHuffmanCode] code_length[%d..%d] = %d\n",
-              *symbol, *symbol + repeat_delta - 1, *repeat_code_len));
+      (int)*symbol, (int)(*symbol + repeat_delta - 1), (int)*repeat_code_len));
   if (*repeat_code_len != 0) {
     unsigned last = *symbol + repeat_delta;
     int next = next_symbol[*repeat_code_len];
@@ -832,7 +833,7 @@ static BrotliDecoderErrorCode ReadHuffmanCode(uint32_t alphabet_size,
         }
 
         if (s->space != 0) {
-          BROTLI_LOG(("[ReadHuffmanCode] space = %d\n", s->space));
+          BROTLI_LOG(("[ReadHuffmanCode] space = %d\n", (int)s->space));
           return BROTLI_FAILURE(BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE);
         }
         table_size = BrotliBuildHuffmanTable(

--- a/java/org/brotli/wrapper/common/SetRfcDictionaryTest.java
+++ b/java/org/brotli/wrapper/common/SetRfcDictionaryTest.java
@@ -9,14 +9,12 @@ package org.brotli.wrapper.common;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.brotli.dec.Dictionary;
 import org.brotli.integration.BrotliJniTestBase;
 import org.brotli.wrapper.dec.BrotliInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.junit.Test;


### PR DESCRIPTION
 * cast logged values to `int` to match `%d` formatter
 * remove `BROTLI_RESTRICT` in `transform.{c,h}` declarations
 * remove unused imports in java RFC dictionary test