### PR TITLE
Update go_library to use standard importpath

### DIFF
--- a/go/BUILD
+++ b/go/BUILD
@@ -1,0 +1,2 @@
+# Description:
+#   cbrotli is a CGo wrapper for Brotli, a generic-purpose lossless compression algorithm.

--- a/go/BUILD
+++ b/go/BUILD
@@ -1,3 +1,0 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
-
-go_prefix("github.com/google/brotli")

--- a/go/cbrotli/BUILD
+++ b/go/cbrotli/BUILD
@@ -2,9 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # MIT
 
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
-
-go_prefix("github.com/google/brotli")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cbrotli",
@@ -16,7 +14,8 @@ go_library(
         "@org_brotli//:brotlidec",
         "@org_brotli//:brotlienc",
     ],
-    cgo=True,
+    cgo = True,
+    importpath = "github.com/google/brotli/go/cbrotli",
 )
 
 go_test(


### PR DESCRIPTION
Instead of using go_prefix, which is deprecated, the importpath attribute is made explicit.