### PR TITLE
Fix auto detect of bundled mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,13 @@ project(brotli C)
 # we'll use the BROTLI_BUNDLED_MODE variable to let them do that; just
 # set it to OFF in your project before you add_subdirectory(brotli).
 get_directory_property(BROTLI_PARENT_DIRECTORY PARENT_DIRECTORY)
-if(BROTLI_BUNDLED_MODE STREQUAL "")
+if(NOT DEFINED BROTLI_BUNDLED_MODE)
   # Bundled mode hasn't been set one way or the other, set the default
   # depending on whether or not we are the top-level project.
   if(BROTLI_PARENT_DIRECTORY)
-    set(BROTLI_BUNDLED_MODE OFF)
-  else()
     set(BROTLI_BUNDLED_MODE ON)
+  else()
+    set(BROTLI_BUNDLED_MODE OFF)
   endif()
 endif()
 mark_as_advanced(BROTLI_BUNDLED_MODE)


### PR DESCRIPTION
Set bundled mode to ON when parent directory is not empty.

This likely never became an issue due to the (strange) way if works in CMake; if you compare an undefined variable to the empty string the result is false. So the code to set BROTLI_BUNDLED_MODE never ran, and the uses later in the file are as boolean values, where undefined is false.
