### PR TITLE
tools/brotli: improve window size autodetect

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -943,10 +943,9 @@ static BROTLI_BOOL CompressFiles(Context* context) {
       uint32_t lgwin = DEFAULT_LGWIN;
       /* Use file size to limit lgwin. */
       if (context->input_file_length >= 0) {
-        int32_t size = 1 << BROTLI_MIN_WINDOW_BITS;
         lgwin = BROTLI_MIN_WINDOW_BITS;
-        while (size < context->input_file_length) {
-          size <<= 1;
+        while (BROTLI_MAX_BACKWARD_LIMIT(lgwin) <
+               (uint64_t)context->input_file_length) {
           lgwin++;
           if (lgwin == BROTLI_MAX_WINDOW_BITS) break;
         }


### PR DESCRIPTION
Window size is defined as:
    `(1 << BROTLI_PARAM_LGWIN) - 16`
in `c/include/brotli/encode.h`

Therefore we should probably take these 16 bytes into account by subtracting them from the available `size`.

Done basic manual testing:
```
$ python3 -c 'print ("A"*2046)' > t
$ bazel run -- //:brotli -w 0 -f -o $(realpath t).br $(realpath ./t)
$ python3 research/brotlidump.py t.br |& fgrep WSIZE
0000  c1                1000001 WSIZE   windowsize=(1<<12)-16=4080
```

New version properly detects window size of `4080`, while previous one used `2032`:
```
$ python3 research/brotlidump.py t.br |& fgrep WSIZE
0000  b1                0110001 WSIZE   windowsize=(1<<11)-16=2032
```