### PR TITLE
Reduce hasher lookups with good matches

### DIFF
--- a/c/enc/backward_references_inc.h
+++ b/c/enc/backward_references_inc.h
@@ -47,10 +47,11 @@ static BROTLI_NOINLINE void EXPORT_FN(CreateBackwardReferences)(
                          params->dist.max_distance, &sr);
     if (sr.score > kMinScore) {
       /* Found a match. Let's look for something even better ahead. */
+      const score_t cost_diff_lazy = 175;
       int delayed_backward_references_in_row = 0;
       --max_length;
-      for (;; --max_length) {
-        const score_t cost_diff_lazy = 175;
+      for (; BackwardReferenceScoreUsingLastDistance(pos_end - (position + 1))
+                 >= sr.score + cost_diff_lazy; --max_length) {
         HasherSearchResult sr2;
         sr2.len = params->quality < MIN_QUALITY_FOR_EXTENSIVE_REFERENCE_SEARCH ?
             BROTLI_MIN(size_t, sr.len - 1, max_length) : 0;


### PR DESCRIPTION
If a match cannot be further improved, we can save a hasher lookup which may constitute a significant portion of compression time on files with long matches. For instance, on BSDiff patch files, the gain in compression time can be >50% for quality 9 (e.g., on the file `none` from [google/brotli/issues/632]).

Although our condition implies that the current match cannot be further improved, the method `FindLongestMatch` is not side-effect free (it affects the statistics of successful static dictionary lookups), and thus the change affects the compressed output in rare cases.

Our benchmarks on standard corpora (calgary, canterbury, silesia) show that the change is safe in terms of compressed size and compression time.