### PR TITLE
decode: fix NEON inclusion

### DIFF
--- a/c/common/platform.h
+++ b/c/common/platform.h
@@ -203,6 +203,10 @@ OR:
 
 #endif  /* ARMv8 */
 
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
+#define BROTLI_TARGET_NEON
+#endif
+
 #if defined(__i386) || defined(_M_IX86)
 #define BROTLI_TARGET_X86
 #endif

--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -6,7 +6,7 @@
 
 #include <brotli/decode.h>
 
-#if defined(__ARM_NEON__)
+#if defined(BROTLI_TARGET_NEON)
 #include <arm_neon.h>
 #endif
 
@@ -167,7 +167,7 @@ static BrotliDecoderErrorCode DecodeWindowBits(BrotliDecoderState* s,
 }
 
 static BROTLI_INLINE void memmove16(uint8_t* dst, uint8_t* src) {
-#if defined(__ARM_NEON__)
+#if defined(BROTLI_TARGET_NEON)
   vst1q_u8(dst, vld1q_u8(src));
 #else
   uint32_t buffer[4];


### PR DESCRIPTION
The macro that checks for NEON support should be __ARM_NEON, not
__ARM_NEON__. [1]

AArch64 compilers define __ARM_NEON but not __ARM_NEON__.
AArch32 compilers currently seem to define both, but could be within their
rights to drop __ARM_NEON__ in future versions.

This change moves the check into the common/platform.h file, checks for
both forms, and sets BROTLI_TARGET_NEON if NEON support is available.

[1] Section 6.5.4 of the ARM C Language Extensions.
    (At the time of writing, the latest version was Release 2.1.)