### PR TITLE
make/build: ensure NEON is enabled and tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
     ## testing arm via qemu on Linux
     ###
     - os: linux
-      env: BUILD_SYSTEM=cmake C_COMPILER=arm-linux-gnueabihf-gcc CXX_COMPILER=arm-linux-gnueabihf-g++
+      env: BUILD_SYSTEM=cmake C_COMPILER=arm-linux-gnueabihf-gcc CXX_COMPILER=arm-linux-gnueabihf-g++ CFLAGS="-march=armv7-a -mfloat-abi=hard -mfpu=neon"
       addons:
         apt:
           sources:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 # The arm-linux-gnueabi compiler defaults to Armv5. Since we only support Armv7
 # and beyond, we need to select Armv7 explicitly with march.
 ifeq ($(ARCH), arm)
-	CFLAGS += -march=armv7-a
+	CFLAGS += -march=armv7-a -mfloat-abi=hard -mfpu=neon
 endif
 
 all: test


### PR DESCRIPTION
Make sure the travis CI aarch32 bot tests NEON, and also that running
CROSS_COMPILE=arm-linux-gnueabihf make enables the use of NEON to
accelerate the back-reference copying.