### PR TITLE
Add runtime linker path to pkg-config files

### DIFF
--- a/scripts/libbrotlicommon.pc.in
+++ b/scripts/libbrotlicommon.pc.in
@@ -7,5 +7,5 @@ Name: libbrotlicommon
 URL: https://github.com/google/brotli
 Description: Brotli common dictionary library
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lbrotlicommon
+Libs: -L${libdir} -R${libdir} -lbrotlicommon
 Cflags: -I${includedir}

--- a/scripts/libbrotlidec.pc.in
+++ b/scripts/libbrotlidec.pc.in
@@ -7,6 +7,6 @@ Name: libbrotlidec
 URL: https://github.com/google/brotli
 Description: Brotli decoder library
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lbrotlidec
+Libs: -L${libdir} -R${libdir} -lbrotlidec
 Requires.private: libbrotlicommon >= 1.0.2
 Cflags: -I${includedir}

--- a/scripts/libbrotlienc.pc.in
+++ b/scripts/libbrotlienc.pc.in
@@ -7,6 +7,6 @@ Name: libbrotlienc
 URL: https://github.com/google/brotli
 Description: Brotli encoder library
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lbrotlienc
+Libs: -L${libdir} -R${libdir} -lbrotlienc
 Requires.private: libbrotlicommon >= 1.0.2
 Cflags: -I${includedir}


### PR DESCRIPTION
Otherwise libraries will not be found at runtime when installing to a path not included in the default runtime linker's path with programs linking brotli configured via pkg-config.