### PR TITLE
Fix config_setting for msvc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+load(":compiler_config_setting.bzl", "create_compiler_config_setting")
+
 licenses(["notice"])  # MIT
 
 exports_files(["LICENSE"])
@@ -39,11 +41,7 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-config_setting(
-    name = "msvc",
-    values = {"compiler": "msvc-cl"},
-    visibility = ["//visibility:public"],
-)
+create_compiler_config_setting(name = "msvc", value = "msvc-cl")
 
 STRICT_C_OPTIONS = select({
     ":msvc": [],

--- a/compiler_config_setting.bzl
+++ b/compiler_config_setting.bzl
@@ -1,0 +1,21 @@
+"""Creates config_setting that allows selecting based on 'compiler' value."""
+
+def create_compiler_config_setting(name, value):
+    # The "do_not_use_tools_cpp_compiler_present" attribute exists to
+    # distinguish between older versions of Bazel that do not support
+    # "@bazel_tools//tools/cpp:compiler" flag_value, and newer ones that do.
+    # In the future, the only way to select on the compiler will be through
+    # flag_values{"@bazel_tools//tools/cpp:compiler"} and the else branch can
+    # be removed.
+    if hasattr(cc_common, "do_not_use_tools_cpp_compiler_present"):
+        native.config_setting(
+            name = name,
+            flag_values = {
+                "@bazel_tools//tools/cpp:compiler": value,
+            },
+        )
+    else:
+        native.config_setting(
+            name = name,
+            values = {"compiler": value},
+        )


### PR DESCRIPTION
Route "compiler" value of config_setting through @bazel_tools/tools/cpp:compiler.
This is necessary for modern Bazel version.