### PR TITLE
Add sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The basic commands to build, test and install brotli are:
     $ ../configure-cmake
     $ make
     $ make test
-    $ make install
+    $ sudo make install
 
 By default, debug binaries are built. To generate "release" `Makefile` specify `--disable-debug` option to `configure-cmake`.
 


### PR DESCRIPTION
Since building the binary should be done using a low-privileges account, administrator will need to sudo (or any other way to escalate privileges) to install brotli.