### PR TITLE
Add oss-fuzz fuzzing status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://groups.google.com/forum/#!forum/brotli
 
 [![TravisCI Build Status](https://travis-ci.org/google/brotli.svg?branch=master)](https://travis-ci.org/google/brotli)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/brotli?branch=master&svg=true)](https://ci.appveyor.com/project/szabadka/brotli)
+[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/brotli.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#brotli)
 
 ### Build instructions
 


### PR DESCRIPTION
We just added fuzzing status badges in oss-fuzz.

This should provide quick at-a-glance information to make sure that the oss-fuzz build is still successful and the project is being continuously fuzzed.