### PR TITLE
Remove the "Only Python 2.7+" line from README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,8 +1,6 @@
 This directory contains the code for the Python `brotli` module,
 `bro.py` tool, and roundtrip tests.
 
-Only Python 2.7+ is supported.
-
 We provide a `Makefile` to simplify common development commands.
 
 ### Installation


### PR DESCRIPTION
Hi!

The README states that "Only Python 2.7+ is supported", while there are Python3 packages [hosted on PyPI](https://pypi.org/project/Brotli/#files) and elsewhere (for example, [Debian repos](https://packages.debian.org/stretch/python3-brotli) also have the python3-brotli package).

So I think this line is outdated, let's drop it.