### PR TITLE
.gitignore: Ignore .obj files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # C
 *.o
+*.obj
 bin/
 buildfiles/
 **/obj/


### PR DESCRIPTION
EDK II windows build produces .obj files in source tree