### PR TITLE
Fix clang-10 compilation issue

### DIFF
--- a/c/enc/bit_cost.h
+++ b/c/enc/bit_cost.h
@@ -45,7 +45,7 @@ static BROTLI_INLINE double BitsEntropy(
     const uint32_t* population, size_t size) {
   size_t sum;
   double retval = ShannonEntropy(population, size, &sum);
-  if (retval < sum) {
+  if (retval < (double)sum) {
     /* At least one bit per literal is needed. */
     retval = (double)sum;
   }


### PR DESCRIPTION
clang-10 throws the following error:
```
In file included from external/org_brotli/c/enc/bit_cost.c:9:
external/org_brotli/c/enc/./bit_cost.h:48:16: error: implicit conversion from 'size_t' (aka 'unsigned long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
  if (retval < sum) {
             ~ ^~~
1 error generated.
```
Make the conversion explicit.