### PR TITLE
Fix MSVC linker error

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -123,7 +123,10 @@ cc_library(
     srcs = [":enc_sources"],
     hdrs = [":enc_headers"],
     copts = STRICT_C_OPTIONS,
-    linkopts = ["-lm"],
+    linkopts = select({
+        ":msvc": [],
+        "//conditions:default": ["-lm"],
+    }),
     deps = [":brotlicommon"],
 )
 


### PR DESCRIPTION
The -lm linker option is not known to MSVC and setting it triggers errors in some build systems:

```
  [6,366 / 6,367] Linking source/exe/envoy-static.exe; 11s remote
  LINK : warning LNK4044: unrecognized option '/lm'; ignored
  LINK : error LNK1218: warning treated as error; no output file generated
  ERROR: C:/source/source/exe/BUILD:22:16: Linking of rule
    '//source/exe:envoy-static' failed (Exit 4044): link.exe failed: error executing command
```

Do not set -lm in case of MSVC.