### PR TITLE
Change MANIFEST.in to include python regression tests in tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,4 +15,5 @@ include python/README.md
 include python/tests/*
 include README.md
 include setup.py
+include tests/testdata/*
 include c/tools/brotli.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include python/_brotli.cc
 include python/bro.py
 include python/brotli.py
 include python/README.md
+include python/tests/*
 include README.md
 include setup.py
 include c/tools/brotli.c


### PR DESCRIPTION
For OpenBSD, we like having the Python regression tests included in the tarball so if any dependencies change, we can easily verify that we haven't broken things. 

This change just adds those test files to the PyPI tarball.