### PR TITLE
Fix VC C++ 12.0 BROTLI_MSVC_VERSION_CHECK calls

### DIFF
--- a/c/common/platform.h
+++ b/c/common/platform.h
@@ -40,7 +40,7 @@
 #define BROTLI_X_BIG_ENDIAN BIG_ENDIAN
 #endif
 
-#if BROTLI_MSVC_VERSION_CHECK(12, 0, 0)
+#if BROTLI_MSVC_VERSION_CHECK(18, 0, 0)
 #include <intrin.h>
 #endif
 
@@ -529,7 +529,7 @@ BROTLI_MIN_MAX(size_t) BROTLI_MIN_MAX(uint32_t) BROTLI_MIN_MAX(uint8_t)
 #if BROTLI_GNUC_HAS_BUILTIN(__builtin_ctzll, 3, 4, 0) || \
     BROTLI_INTEL_VERSION_CHECK(16, 0, 0)
 #define BROTLI_TZCNT64 __builtin_ctzll
-#elif BROTLI_MSVC_VERSION_CHECK(12, 0, 0)
+#elif BROTLI_MSVC_VERSION_CHECK(18, 0, 0)
 #if defined(BROTLI_TARGET_X64)
 #define BROTLI_TZCNT64 _tzcnt_u64
 #else /* BROTLI_TARGET_X64 */
@@ -546,7 +546,7 @@ static BROTLI_INLINE uint32_t BrotliBsf64Msvc(uint64_t x) {
 #if BROTLI_GNUC_HAS_BUILTIN(__builtin_clz, 3, 4, 0) || \
     BROTLI_INTEL_VERSION_CHECK(16, 0, 0)
 #define BROTLI_BSR32(x) (31u ^ (uint32_t)__builtin_clz(x))
-#elif BROTLI_MSVC_VERSION_CHECK(12, 0, 0)
+#elif BROTLI_MSVC_VERSION_CHECK(18, 0, 0)
 static BROTLI_INLINE uint32_t BrotliBsr32Msvc(uint32_t x) {
   unsigned long msb;
   _BitScanReverse(&msb, x);


### PR DESCRIPTION
fix https://github.com/google/brotli/issues/837

I was able to try it out locally on Python 2.7 with VC C++ 9.0. This did fix the issue. If possible, it would be nice to have a new version available on PyPy as soon as possible, since 1.0.7 suffers from CVEs.

I really wonder why this wasn't triggered by your test base.
```
Environment: BUILD_SYSTEM=Python, PYTHON=C:\Python27, PYTHON_VERSION=2.7.x, PYTHON_ARCH=32
```
fits the description :/