### PR TITLE
Fix typo in variable name

### DIFF
--- a/java/org/brotli/wrapper/dec/Decoder.java
+++ b/java/org/brotli/wrapper/dec/Decoder.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
  * Base class for InputStream / Channel implementations.
  */
 public class Decoder {
-  private static final ByteBuffer EMPTY_BUFER = ByteBuffer.allocate(0);
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
   private final ReadableByteChannel source;
   private final DecoderJNI.Wrapper decoder;
   ByteBuffer buffer;

--- a/java/org/brotli/wrapper/dec/Decoder.java
+++ b/java/org/brotli/wrapper/dec/Decoder.java
@@ -91,7 +91,7 @@ public class Decoder {
           }
           if (bytesRead == 0) {
             // No input data is currently available.
-            buffer = EMPTY_BUFER;
+            buffer = EMPTY_BUFFER;
             return 0;
           }
           decoder.push(bytesRead);


### PR DESCRIPTION
Fix typo in `EMPTY_BUFER`. 

Changed `EMPTY_BUFER` to `EMPTY_BUFFER`.