### PR TITLE
 Python: use a new output buffer code

### DIFF
--- a/python/_brotli.c
+++ b/python/_brotli.c
@@ -369,7 +369,7 @@ static int brotli_Compressor_init(brotli_Compressor *self, PyObject *args, PyObj
   static const char *kwlist[] = {"mode", "quality", "lgwin", "lgblock", NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "|O&O&O&O&:Compressor",
-                    const_cast<char **>(kwlist),
+                    (char**) kwlist,
                     &mode_convertor, &mode,
                     &quality_convertor, &quality,
                     &lgwin_convertor, &lgwin,
@@ -431,7 +431,7 @@ static PyObject* brotli_Compressor_process(brotli_Compressor *self, PyObject *ar
   }
 
   ok = compress_stream(self->enc, BROTLI_OPERATION_PROCESS,
-                       &ret, static_cast<uint8_t*>(input.buf), input.len);
+                       &ret, (uint8_t*) input.buf, input.len);
 
 end:
   PyBuffer_Release(&input);
@@ -660,7 +660,7 @@ static int brotli_Decompressor_init(brotli_Decompressor *self, PyObject *args, P
   static const char *kwlist[] = {NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "|:Decompressor",
-                    const_cast<char **>(kwlist));
+                    (char**) kwlist);
   if (!ok)
     return -1;
   if (!self->dec)
@@ -708,7 +708,7 @@ static PyObject* brotli_Decompressor_process(brotli_Decompressor *self, PyObject
     goto end;
   }
 
-  ok = decompress_stream(self->dec, &ret, static_cast<uint8_t*>(input.buf), input.len);
+  ok = decompress_stream(self->dec, &ret, (uint8_t*) input.buf, input.len);
 
 end:
   PyBuffer_Release(&input);
@@ -832,10 +832,10 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
 
 #if PY_MAJOR_VERSION >= 3
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "y*|:decompress",
-                                   const_cast<char **>(kwlist), &input);
+                                   (char**) kwlist, &input);
 #else
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "s*|:decompress",
-                                   const_cast<char **>(kwlist), &input);
+                                   (char**) kwlist, &input);
 #endif
 
   if (!ok)
@@ -850,7 +850,7 @@ static PyObject* brotli_decompress(PyObject *self, PyObject *args, PyObject *key
   BrotliDecoderState* state = BrotliDecoderCreateInstance(0, 0, 0);
 
   BrotliDecoderResult result = BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT;
-  next_in = static_cast<uint8_t*>(input.buf);
+  next_in = (uint8_t*) input.buf;
   available_in = input.len;
   while (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
     result = BrotliDecoderDecompressStream(state, &available_in, &next_in,

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -459,8 +459,7 @@ PyDoc_STRVAR(brotli_Compressor_flush_doc,
 "  brotli.error: If compression fails\n");
 
 static PyObject* brotli_Compressor_flush(brotli_Compressor *self) {
-  PyObject *ret = NULL;
-  std::vector<uint8_t> output;
+  PyObject *ret;
   BROTLI_BOOL ok = BROTLI_TRUE;
 
   if (!self->enc) {
@@ -469,12 +468,11 @@ static PyObject* brotli_Compressor_flush(brotli_Compressor *self) {
   }
 
   ok = compress_stream(self->enc, BROTLI_OPERATION_FLUSH,
-                       &output, NULL, 0);
+                       &ret, NULL, 0);
 
 end:
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.size() ? &output[0] : NULL), output.size());
-  } else {
+  if (!ok) {
+    ret = NULL;
     PyErr_SetString(BrotliError, "BrotliEncoderCompressStream failed while flushing the stream");
   }
 

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -497,8 +497,7 @@ PyDoc_STRVAR(brotli_Compressor_finish_doc,
 "  brotli.error: If compression fails\n");
 
 static PyObject* brotli_Compressor_finish(brotli_Compressor *self) {
-  PyObject *ret = NULL;
-  std::vector<uint8_t> output;
+  PyObject *ret;
   BROTLI_BOOL ok = BROTLI_TRUE;
 
   if (!self->enc) {
@@ -507,16 +506,15 @@ static PyObject* brotli_Compressor_finish(brotli_Compressor *self) {
   }
 
   ok = compress_stream(self->enc, BROTLI_OPERATION_FINISH,
-                       &output, NULL, 0);
+                       &ret, NULL, 0);
 
   if (ok) {
     ok = BrotliEncoderIsFinished(self->enc);
   }
 
 end:
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.empty() ? NULL : &output[0]), output.size());
-  } else {
+  if (!ok) {
+    ret = NULL;
     PyErr_SetString(BrotliError, "BrotliEncoderCompressStream failed while finishing the stream");
   }
 

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -10,9 +10,187 @@
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_Check PyLong_Check
 #define PyInt_AsLong PyLong_AsLong
+#else
+#define Py_ARRAY_LENGTH(array)  (sizeof(array) / sizeof((array)[0]))
 #endif
 
 static PyObject *BrotliError;
+
+
+/* -----------------------------------
+     BlocksOutputBuffer code
+   ----------------------------------- */
+typedef struct {
+    /* List of blocks */
+    PyObject *list;
+    /* Number of whole allocated size. */
+    Py_ssize_t allocated;
+} BlocksOutputBuffer;
+
+/* Block size sequence. Below functions assume the type is int. */
+#define KB (1024)
+#define MB (1024*1024)
+static const int BUFFER_BLOCK_SIZE[] =
+    { 32*KB, 64*KB, 256*KB, 1*MB, 4*MB, 8*MB, 16*MB, 16*MB,
+      32*MB, 32*MB, 32*MB, 32*MB, 64*MB, 64*MB, 128*MB, 128*MB,
+      256*MB };
+#undef KB
+#undef MB
+
+/* According to the block sizes defined by BUFFER_BLOCK_SIZE, the whole
+   allocated size growth step is:
+    1   32 KB       +32 KB
+    2   96 KB       +64 KB
+    3   352 KB      +256 KB
+    4   1.34 MB     +1 MB
+    5   5.34 MB     +4 MB
+    6   13.34 MB    +8 MB
+    7   29.34 MB    +16 MB
+    8   45.34 MB    +16 MB
+    9   77.34 MB    +32 MB
+    10  109.34 MB   +32 MB
+    11  141.34 MB   +32 MB
+    12  173.34 MB   +32 MB
+    13  237.34 MB   +64 MB
+    14  301.34 MB   +64 MB
+    15  429.34 MB   +128 MB
+    16  557.34 MB   +128 MB
+    17  813.34 MB   +256 MB
+    18  1069.34 MB  +256 MB
+    19  1325.34 MB  +256 MB
+    20  1581.34 MB  +256 MB
+    21  1837.34 MB  +256 MB
+    22  2093.34 MB  +256 MB
+    ...
+*/
+
+/* Initialize the buffer, and grow the buffer.
+   Return 0 on success
+   Return -1 on failure
+*/
+static int
+BlocksOutputBuffer_InitAndGrow(BlocksOutputBuffer *buffer,
+                               size_t *avail_out, uint8_t **next_out)
+{
+    PyObject *b;
+    const int block_size = BUFFER_BLOCK_SIZE[0];
+
+    // The first block
+    b = PyBytes_FromStringAndSize(NULL, block_size);
+    if (b == NULL) {
+        buffer->list = NULL;
+        return -1;
+    }
+
+    // Create list
+    buffer->list = PyList_New(1);
+    if (buffer->list == NULL) {
+        Py_DECREF(b);
+        return -1;
+    }
+    PyList_SET_ITEM(buffer->list, 0, b);
+
+    // Set variables
+    buffer->allocated = block_size;
+
+    *avail_out = block_size;
+    *next_out = (uint8_t*) PyBytes_AS_STRING(b);
+    return 0;
+}
+
+/* Grow the buffer. The avail_out must be 0, please check it before calling.
+   Return 0 on success
+   Return -1 on failure
+*/
+static int
+BlocksOutputBuffer_Grow(BlocksOutputBuffer *buffer,
+                        size_t *avail_out, uint8_t **next_out)
+{
+    PyObject *b;
+    const Py_ssize_t list_len = Py_SIZE(buffer->list);
+    int block_size;
+
+    // Ensure no gaps in the data
+    assert(*avail_out == 0);
+
+    // Get block size
+    if (list_len < (Py_ssize_t) Py_ARRAY_LENGTH(BUFFER_BLOCK_SIZE)) {
+        block_size = BUFFER_BLOCK_SIZE[list_len];
+    } else {
+        block_size = BUFFER_BLOCK_SIZE[Py_ARRAY_LENGTH(BUFFER_BLOCK_SIZE) - 1];
+    }
+
+    // Create the block
+    b = PyBytes_FromStringAndSize(NULL, block_size);
+    if (b == NULL) {
+        Py_CLEAR(buffer->list);
+
+        PyErr_SetString(PyExc_MemoryError, "Unable to allocate output buffer.");
+        return -1;
+    }
+    if (PyList_Append(buffer->list, b) < 0) {
+        Py_DECREF(b);
+        Py_CLEAR(buffer->list);
+        return -1;
+    }
+    Py_DECREF(b);
+
+    // Set variables
+    buffer->allocated += block_size;
+
+    *avail_out = block_size;
+    *next_out = (uint8_t*) PyBytes_AS_STRING(b);
+    return 0;
+}
+
+/* Finish the buffer.
+   Return a bytes object on success
+   Return NULL on failure
+*/
+static PyObject *
+BlocksOutputBuffer_Finish(BlocksOutputBuffer *buffer, size_t avail_out)
+{
+    PyObject *result, *block;
+    char *offset;
+    Py_ssize_t i;
+
+    // Final bytes object
+    result = PyBytes_FromStringAndSize(NULL, buffer->allocated - avail_out);
+    if (result == NULL) {
+        Py_CLEAR(buffer->list);
+
+        PyErr_SetString(PyExc_MemoryError, "Unable to allocate output buffer.");
+        return NULL;
+    }
+
+    // Memory copy
+    if (Py_SIZE(buffer->list) > 0) {
+        offset = PyBytes_AS_STRING(result);
+
+        // blocks except the last one. Note the scope of i.
+        for (i = 0; i < Py_SIZE(buffer->list)-1; i++) {
+            block = PyList_GET_ITEM(buffer->list, i);
+            memcpy(offset,  PyBytes_AS_STRING(block), Py_SIZE(block));
+            offset += Py_SIZE(block);
+        }
+        // the last block
+        block = PyList_GET_ITEM(buffer->list, i);
+        memcpy(offset, PyBytes_AS_STRING(block), Py_SIZE(block) - avail_out);
+    } else {
+        assert(Py_SIZE(result) == 0);
+    }
+
+    Py_CLEAR(buffer->list);
+    return result;
+}
+
+/* Clean up the buffer */
+static void
+BlocksOutputBuffer_CleanUp(BlocksOutputBuffer *buffer)
+{
+  Py_XDECREF(buffer->list);
+}
+
 
 static int as_bounded_int(PyObject *o, int* result, int lower_bound, int upper_bound) {
   long value = PyInt_AsLong(o);

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -691,8 +691,7 @@ PyDoc_STRVAR(brotli_Decompressor_process_doc,
 "  brotli.error: If decompression fails\n");
 
 static PyObject* brotli_Decompressor_process(brotli_Decompressor *self, PyObject *args) {
-  PyObject* ret = NULL;
-  std::vector<uint8_t> output;
+  PyObject* ret;
   Py_buffer input;
   BROTLI_BOOL ok = BROTLI_TRUE;
 
@@ -710,13 +709,12 @@ static PyObject* brotli_Decompressor_process(brotli_Decompressor *self, PyObject
     goto end;
   }
 
-  ok = decompress_stream(self->dec, &output, static_cast<uint8_t*>(input.buf), input.len);
+  ok = decompress_stream(self->dec, &ret, static_cast<uint8_t*>(input.buf), input.len);
 
 end:
   PyBuffer_Release(&input);
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.empty() ? NULL : &output[0]), output.size());
-  } else {
+  if (!ok) {
+    ret = NULL;
     PyErr_SetString(BrotliError, "BrotliDecoderDecompressStream failed while processing the stream");
   }
 

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -2,7 +2,6 @@
 #include <Python.h>
 #include <bytesobject.h>
 #include <structmember.h>
-#include <vector>
 #include "../common/version.h"
 #include <brotli/decode.h>
 #include <brotli/encode.h>
@@ -736,14 +735,9 @@ PyDoc_STRVAR(brotli_Decompressor_is_finished_doc,
 "  brotli.error: If decompression fails\n");
 
 static PyObject* brotli_Decompressor_is_finished(brotli_Decompressor *self) {
-  PyObject *ret = NULL;
-  std::vector<uint8_t> output;
-  BROTLI_BOOL ok = BROTLI_TRUE;
-
   if (!self->dec) {
-    ok = BROTLI_FALSE;
     PyErr_SetString(BrotliError, "BrotliDecoderState is NULL while checking is_finished");
-    goto end;
+    return NULL;
   }
 
   if (BrotliDecoderIsFinished(self->dec)) {
@@ -751,15 +745,6 @@ static PyObject* brotli_Decompressor_is_finished(brotli_Decompressor *self) {
   } else {
     Py_RETURN_FALSE;
   }
-
-end:
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.empty() ? NULL : &output[0]), output.size());
-  } else {
-    PyErr_SetString(BrotliError, "BrotliDecoderDecompressStream failed while finishing the stream");
-  }
-
-  return ret;
 }
 
 static PyMemberDef brotli_Decompressor_members[] = {

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -413,8 +413,7 @@ PyDoc_STRVAR(brotli_Compressor_process_doc,
 "  brotli.error: If compression fails\n");
 
 static PyObject* brotli_Compressor_process(brotli_Compressor *self, PyObject *args) {
-  PyObject* ret = NULL;
-  std::vector<uint8_t> output;
+  PyObject* ret;
   Py_buffer input;
   BROTLI_BOOL ok = BROTLI_TRUE;
 
@@ -433,13 +432,12 @@ static PyObject* brotli_Compressor_process(brotli_Compressor *self, PyObject *ar
   }
 
   ok = compress_stream(self->enc, BROTLI_OPERATION_PROCESS,
-                       &output, static_cast<uint8_t*>(input.buf), input.len);
+                       &ret, static_cast<uint8_t*>(input.buf), input.len);
 
 end:
   PyBuffer_Release(&input);
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.size() ? &output[0] : NULL), output.size());
-  } else {
+  if (!ok) {
+    ret = NULL;
     PyErr_SetString(BrotliError, "BrotliEncoderCompressStream failed while processing the stream");
   }
 

--- a/setup.py
+++ b/setup.py
@@ -71,40 +71,33 @@ class BuildExt(build_ext):
             log.info("building '%s' extension", ext.name)
 
         c_sources = []
-        cxx_sources = []
         for source in ext.sources:
             if source.endswith('.c'):
                 c_sources.append(source)
-            else:
-                cxx_sources.append(source)
         extra_args = ext.extra_compile_args or []
 
         objects = []
-        for lang, sources in (('c', c_sources), ('c++', cxx_sources)):
-            if lang == 'c++':
-                if self.compiler.compiler_type == 'msvc':
-                    extra_args.append('/EHsc')
 
-            macros = ext.define_macros[:]
-            if platform.system() == 'Darwin':
-                macros.append(('OS_MACOSX', '1'))
-            elif self.compiler.compiler_type == 'mingw32':
-                # On Windows Python 2.7, pyconfig.h defines "hypot" as "_hypot",
-                # This clashes with GCC's cmath, and causes compilation errors when
-                # building under MinGW: http://bugs.python.org/issue11566
-                macros.append(('_hypot', 'hypot'))
-            for undef in ext.undef_macros:
-                macros.append((undef,))
+        macros = ext.define_macros[:]
+        if platform.system() == 'Darwin':
+            macros.append(('OS_MACOSX', '1'))
+        elif self.compiler.compiler_type == 'mingw32':
+            # On Windows Python 2.7, pyconfig.h defines "hypot" as "_hypot",
+            # This clashes with GCC's cmath, and causes compilation errors when
+            # building under MinGW: http://bugs.python.org/issue11566
+            macros.append(('_hypot', 'hypot'))
+        for undef in ext.undef_macros:
+            macros.append((undef,))
 
-            objs = self.compiler.compile(
-                sources,
-                output_dir=self.build_temp,
-                macros=macros,
-                include_dirs=ext.include_dirs,
-                debug=self.debug,
-                extra_postargs=extra_args,
-                depends=ext.depends)
-            objects.extend(objs)
+        objs = self.compiler.compile(
+            c_sources,
+            output_dir=self.build_temp,
+            macros=macros,
+            include_dirs=ext.include_dirs,
+            debug=self.debug,
+            extra_postargs=extra_args,
+            depends=ext.depends)
+        objects.extend(objs)
 
         self._built_objects = objects[:]
         if ext.extra_objects:
@@ -117,7 +110,7 @@ class BuildExt(build_ext):
 
         ext_path = self.get_ext_fullpath(ext.name)
         # Detect target language, if not provided
-        language = ext.language or self.compiler.detect_language(sources)
+        language = ext.language or self.compiler.detect_language(c_sources)
 
         self.compiler.link_shared_object(
             objects,
@@ -180,7 +173,7 @@ EXT_MODULES = [
     Extension(
         '_brotli',
         sources=[
-            'python/_brotli.cc',
+            'python/_brotli.c',
             'c/common/constants.c',
             'c/common/context.c',
             'c/common/dictionary.c',
@@ -267,8 +260,7 @@ EXT_MODULES = [
         ],
         include_dirs=[
             'c/include',
-        ],
-        language='c++'),
+        ]),
 ]
 
 TEST_SUITE = 'setup.get_test_suite'


### PR DESCRIPTION
Currently, the output buffer is a `std::vector<uint8_t>`.
When the buffer grows, resizing will cause unnecessary `memcpy()`.

This PR uses a list of bytes object to represent output buffer, can avoid the extra overhead of resizing.
In addition, C++ code can be removed, it's a pure C extension.

Please review the 11 commits one by one.

Benchmarks:
```
The first column is output date size, the unit is MB.
The second and third columns are consumed time, in seconds.

size before   after
0    0.00006  0.00001
10   0.02449  0.02165
20   0.04640  0.03691
30   0.06695  0.05128
40   0.08199  0.06622
50   0.10581  0.08062
60   0.12336  0.09513
70   0.15077  0.11034
80   0.16498  0.12552
90   0.17981  0.13893
100  0.21600  0.15383
110  0.22965  0.17016
120  0.24485  0.18513
130  0.26064  0.19902
140  0.30751  0.21165
150  0.32188  0.22795
160  0.34317  0.24160
170  0.35872  0.25647
180  0.36515  0.27271
190  0.38189  0.28756
200  0.39475  0.30176
```

```
The first column is output date size, the unit is KB.

size before   after
0    0.00672  0.00669
20   0.00007  0.00011
40   0.00010  0.00013
60   0.00016  0.00017
80   0.00032  0.00024
100  0.00034  0.00028
120  0.00041  0.00032
140  0.00053  0.00037
160  0.00048  0.00043
180  0.00054  0.00057
200  0.00052  0.00053
220  0.00056  0.00071
240  0.00062  0.00062
260  0.00081  0.00071
280  0.00085  0.00090
300  0.00093  0.00090
320  0.00093  0.00093
340  0.00098  0.00091
360  0.00104  0.00106
380  0.00103  0.00142
400  0.00105  0.00114
420  0.00121  0.00116
440  0.00118  0.00128
460  0.00123  0.00137
480  0.00122  0.00178
500  0.00148  0.00142
```

Benchmark code:
```python
from time import perf_counter
from brotli import *

MB = 1024*1024
KB = 1024

for i in range(0, 200*MB+1, 10*MB):
    dat1 = i * b'a'
    dat2 = compress(dat1)
    
    t1 = perf_counter()
    dat3 = decompress(dat2)
    t2 = perf_counter()
    print(i//MB, '%.5f' % (t2-t1))
    
    assert dat1 == dat3
    
for i in range(0, 500*KB+1, 20*KB):
    dat1 = i * b'a'
    dat2 = compress(dat1)
    
    t1 = perf_counter()
    dat3 = decompress(dat2)
    t2 = perf_counter()
    print(i//KB, '%.5f' % (t2-t1))
    
    assert dat1 == dat3
```