### PR TITLE
Include testdata in tarball (#850)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -48,7 +48,4 @@ tests !export-ignore
 tests/*.sh !export-ignore
 tests/*.cmake !export-ignore
 tests/testdata !export-ignore
-tests/testdata/empty !export-ignore
-tests/testdata/empty.compressed !export-ignore
-tests/testdata/ukkonooa !export-ignore
-tests/testdata/ukkonooa.compressed !export-ignore
+tests/testdata/** !export-ignore


### PR DESCRIPTION
Distributions and users run tests to ensure brotli is working and testdata is required for those tests.

This commit brings the git source tarball in alignment with the PyPI tarball which already includes this testdata, see commit f2ca32e.