### PR TITLE
Fix: Build from Bazel

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -54,9 +54,9 @@ java_library(
 cc_binary(
     name = "brotli_jni.dll",
     srcs = [
-        "//org/brotli/wrapper/common:jni_src",
-        "//org/brotli/wrapper/dec:jni_src",
-        "//org/brotli/wrapper/enc:jni_src",
+        "@org_brotli//java/org/brotli/wrapper/common:jni_src",
+        "@org_brotli//java/org/brotli/wrapper/dec:jni_src",
+        "@org_brotli//java/org/brotli/wrapper/enc:jni_src",
         "@org_brotli//:common_headers",
         "@org_brotli//:common_sources",
         "@org_brotli//:dec_headers",
@@ -77,9 +77,9 @@ cc_binary(
 cc_binary(
     name = "brotli_jni_no_dictionary_data.dll",
     srcs = [
-        "//org/brotli/wrapper/common:jni_src",
-        "//org/brotli/wrapper/dec:jni_src",
-        "//org/brotli/wrapper/enc:jni_src",
+        "@org_brotli//java/org/brotli/wrapper/common:jni_src",
+        "@org_brotli//java/org/brotli/wrapper/dec:jni_src",
+        "@org_brotli//java/org/brotli/wrapper/enc:jni_src",
         "@org_brotli//:common_headers",
         "@org_brotli//:common_sources",
         "@org_brotli//:dec_headers",

--- a/java/org/brotli/wrapper/enc/BUILD
+++ b/java/org/brotli/wrapper/enc/BUILD
@@ -27,9 +27,9 @@ java_library(
     srcs = glob(["*Test*.java"]),
     deps = [
         ":enc",
-        "@org_brotli//org/brotli/integration:brotli_jni_test_base",
-        "@org_brotli//org/brotli/integration:bundle_helper",
-        "@org_brotli//org/brotli/wrapper/dec",
+        "@org_brotli//java/org/brotli/integration:brotli_jni_test_base",
+        "@org_brotli//java/org/brotli/integration:bundle_helper",
+        "@org_brotli//java/org/brotli/wrapper/dec",
         "@maven//:junit_junit",
     ],
 )

--- a/java/org/brotli/wrapper/enc/BUILD
+++ b/java/org/brotli/wrapper/enc/BUILD
@@ -9,7 +9,7 @@ filegroup(
 
 filegroup(
     name = "brotli_jni",
-    srcs = ["//:brotli_jni.dll"],
+    srcs = ["@org_brotli//java:brotli_jni.dll"],
 )
 
 java_library(
@@ -18,7 +18,7 @@ java_library(
         ["*.java"],
         exclude = ["*Test*.java"],
     ),
-    resource_jars = ["//:license"],
+    resource_jars = ["@org_brotli//java:license"],
 )
 
 java_library(
@@ -27,16 +27,16 @@ java_library(
     srcs = glob(["*Test*.java"]),
     deps = [
         ":enc",
-        "//org/brotli/integration:brotli_jni_test_base",
-        "//org/brotli/integration:bundle_helper",
-        "//org/brotli/wrapper/dec",
+        "@org_brotli//org/brotli/integration:brotli_jni_test_base",
+        "@org_brotli//org/brotli/integration:bundle_helper",
+        "@org_brotli//org/brotli/wrapper/dec",
         "@maven//:junit_junit",
     ],
 )
 
 filegroup(
     name = "test_bundle",
-    srcs = ["//org/brotli/integration:test_corpus"],
+    srcs = ["@org_brotli//org/brotli/integration:test_corpus"],
 )
 
 java_test(

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -1,0 +1,32 @@
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+
+def load_brotli_repositories():
+  http_file(
+      name = "openjdk_jni_h",
+      downloaded_file_path = "jni.h",
+      urls = ["https://hg.openjdk.java.net/jdk8/jdk8/jdk/raw-file/687fd7c7986d/src/share/javavm/export/jni.h"],
+      sha256 = "ed99792df48670072b78028faf704a8dcb6868fe140ccc7eced9b01dfa62fef4",
+  )
+
+  http_file(
+      name = "openjdk_solaris_jni_md_h",
+      downloaded_file_path = "jni_md.h",
+      urls = ["https://hg.openjdk.java.net/jdk8/jdk8/jdk/raw-file/687fd7c7986d/src/solaris/javavm/export/jni_md.h"],
+      sha256 = "ecbe6944fe1a4290644d5a6b3c8f68576798a53b9da12cd31c58c48569595ff7",
+  )
+
+  http_file(
+      name = "openjdk_macosx_jni_md_h",
+      downloaded_file_path = "jni_md.h",
+      urls = ["https://hg.openjdk.java.net/jdk8/jdk8/jdk/raw-file/687fd7c7986d/src/macosx/javavm/export/jni_md.h"],
+      sha256 = "8f718071022e7e7f2fc9a229984b7e83582db91ed83861b49ce1461436fe8dc4",
+  )
+
+  http_file(
+      name = "openjdk_windows_jni_md_h",
+      downloaded_file_path = "jni_md.h",
+      urls = ["https://hg.openjdk.java.net/jdk8/jdk8/jdk/raw-file/687fd7c7986d/src/windows/javavm/export/jni_md.h"],
+      sha256 = "5479fb385ea1e11619f5c0cdfd9ccb3ea3a3fea0f5bc6176fb3ce62be29d759b",
+  )


### PR DESCRIPTION
This changeset applies fixes to enable `org_brotli` to be used directly from downstream Bazel builds.