### PR TITLE
unichr was removed in Python 3 because all str are Unicode

### DIFF
--- a/scripts/dictionary/step-04-generate-java-literals.py
+++ b/scripts/dictionary/step-04-generate-java-literals.py
@@ -15,6 +15,11 @@
 #
 # This script generates literals used in Java code.
 
+try:
+  unichr  # Python 2
+except NameError
+  unichr = chr  # Python 3
+
 bin_path = "dictionary.bin"
 
 with open(bin_path, "rb") as raw:


### PR DESCRIPTION
https://python-future.org/compatible_idioms.html#unichr