### PR TITLE
[WIP] copy nsec of atime/mtime in CopyStat #891

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -663,8 +663,14 @@ static void CopyStat(const char* input_path, const char* output_path) {
 
   times[0].tv_sec = statbuf.st_atime;
   times[1].tv_sec = statbuf.st_mtime;
+
+#if defined(__GLIBC__)
   times[0].tv_nsec = statbuf.st_atim.tv_nsec;
   times[1].tv_nsec = statbuf.st_mtim.tv_nsec;
+#elif defined(__APPLE__) && !defined(_POSIX_C_SOURCE)
+  times[0].tv_nsec = statbuf.st_atimespec.tv_nsec;
+  times[1].tv_nsec = statbuf.st_mtimespec.tv_nsec;
+#endif
 
   res = utimensat(AT_FDCWD, output_path, times, AT_SYMLINK_NOFOLLOW);
   if (res != 0){


### PR DESCRIPTION
for #891 

copy tv_nsec in stat result to dest file.
switching case for APPLE & GLIBC for compatibility but I don't make sure this coves all case.
if this command need to cover windows, I think it needs more switching but I don't have windows env,
so adding [wip] for here and any comments and helps are welcome.