### PR TITLE
Fix VLA parameter warning

### DIFF
--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -2033,8 +2033,10 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 }
 
 BrotliDecoderResult BrotliDecoderDecompress(
-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
-    uint8_t* decoded_buffer) {
+    size_t encoded_size,
+    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
+    size_t* decoded_size,
+    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]) {
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -1470,8 +1470,9 @@ static size_t MakeUncompressedStream(
 
 BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
-    const uint8_t* input_buffer, size_t* encoded_size,
-    uint8_t* encoded_buffer) {
+    const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
+    size_t* encoded_size,
+    uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]) {
   BrotliEncoderState* s;
   size_t out_size = *encoded_size;
   const uint8_t* input_start = input_buffer;


### PR DESCRIPTION
Make VLA buffer types consistent in declarations and definitions.
Resolves build crash when using -Werror due to "vla-parameter" warning.

Signed-off-by: Adrian Herrera <adr.her.arc.95@gmail.com>