### PR TITLE
Python: use a new output buffer code

### DIFF
--- a/python/_brotli.c
+++ b/python/_brotli.c
@@ -2,7 +2,6 @@
 #include <Python.h>
 #include <bytesobject.h>
 #include <structmember.h>
-#include <vector>
 #include "../common/version.h"
 #include <brotli/decode.h>
 #include <brotli/encode.h>
@@ -380,7 +379,7 @@ static int brotli_Compressor_init(brotli_Compressor *self, PyObject *args, PyObj
   static const char *kwlist[] = {"mode", "quality", "lgwin", "lgblock", NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "|O&O&O&O&:Compressor",
-                    const_cast<char **>(kwlist),
+                    (char**) kwlist,
                     &mode_convertor, &mode,
                     &quality_convertor, &quality,
                     &lgwin_convertor, &lgwin,
@@ -672,7 +671,7 @@ static int brotli_Decompressor_init(brotli_Decompressor *self, PyObject *args, P
   static const char *kwlist[] = {NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "|:Decompressor",
-                    const_cast<char **>(kwlist));
+                                   (char **) kwlist);
   if (!ok)
     return -1;
   if (!self->dec)

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -470,25 +470,23 @@ PyDoc_STRVAR(brotli_Compressor_flush_doc,
 "  brotli.error: If compression fails\n");
 
 static PyObject* brotli_Compressor_flush(brotli_Compressor *self) {
-  PyObject *ret = NULL;
-  std::vector<uint8_t> output;
-  BROTLI_BOOL ok = BROTLI_TRUE;
+  PyObject *ret;
 
   if (!self->enc) {
-    ok = BROTLI_FALSE;
-    goto end;
+    goto error;
   }
 
-  ok = compress_stream(self->enc, BROTLI_OPERATION_FLUSH,
-                       &output, NULL, 0);
-
-end:
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.size() ? &output[0] : NULL), output.size());
-  } else {
-    PyErr_SetString(BrotliError, "BrotliEncoderCompressStream failed while flushing the stream");
+  ret = compress_stream(self->enc, BROTLI_OPERATION_FLUSH,
+                        NULL, 0);
+  if (ret != NULL) {
+    goto final;
   }
 
+error:
+  PyErr_SetString(BrotliError,
+                  "BrotliEncoderCompressStream failed while flushing the stream");
+  ret = NULL;
+final:
   return ret;
 }
 

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -748,14 +748,9 @@ PyDoc_STRVAR(brotli_Decompressor_is_finished_doc,
 "  brotli.error: If decompression fails\n");
 
 static PyObject* brotli_Decompressor_is_finished(brotli_Decompressor *self) {
-  PyObject *ret = NULL;
-  std::vector<uint8_t> output;
-  BROTLI_BOOL ok = BROTLI_TRUE;
-
   if (!self->dec) {
-    ok = BROTLI_FALSE;
     PyErr_SetString(BrotliError, "BrotliDecoderState is NULL while checking is_finished");
-    goto end;
+    return NULL;
   }
 
   if (BrotliDecoderIsFinished(self->dec)) {
@@ -763,15 +758,6 @@ static PyObject* brotli_Decompressor_is_finished(brotli_Decompressor *self) {
   } else {
     Py_RETURN_FALSE;
   }
-
-end:
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.empty() ? NULL : &output[0]), output.size());
-  } else {
-    PyErr_SetString(BrotliError, "BrotliDecoderDecompressStream failed while finishing the stream");
-  }
-
-  return ret;
 }
 
 static PyMemberDef brotli_Decompressor_members[] = {

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -423,36 +423,35 @@ PyDoc_STRVAR(brotli_Compressor_process_doc,
 "  brotli.error: If compression fails\n");
 
 static PyObject* brotli_Compressor_process(brotli_Compressor *self, PyObject *args) {
-  PyObject* ret = NULL;
-  std::vector<uint8_t> output;
+  PyObject* ret;
   Py_buffer input;
-  BROTLI_BOOL ok = BROTLI_TRUE;
+  int ok;
 
 #if PY_MAJOR_VERSION >= 3
-  ok = (BROTLI_BOOL)PyArg_ParseTuple(args, "y*:process", &input);
+  ok = PyArg_ParseTuple(args, "y*:process", &input);
 #else
-  ok = (BROTLI_BOOL)PyArg_ParseTuple(args, "s*:process", &input);
+  ok = PyArg_ParseTuple(args, "s*:process", &input);
 #endif
 
   if (!ok)
     return NULL;
 
   if (!self->enc) {
-    ok = BROTLI_FALSE;
+    goto error;
+  }
+
+  ret = compress_stream(self->enc, BROTLI_OPERATION_PROCESS,
+                        (uint8_t*) input.buf, input.len);
+  if (ret != NULL) {
     goto end;
   }
 
-  ok = compress_stream(self->enc, BROTLI_OPERATION_PROCESS,
-                       &output, static_cast<uint8_t*>(input.buf), input.len);
-
+error:
+  PyErr_SetString(BrotliError,
+                  "BrotliEncoderCompressStream failed while processing the stream");
+  ret = NULL;
 end:
   PyBuffer_Release(&input);
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.size() ? &output[0] : NULL), output.size());
-  } else {
-    PyErr_SetString(BrotliError, "BrotliEncoderCompressStream failed while processing the stream");
-  }
-
   return ret;
 }
 

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -508,29 +508,25 @@ PyDoc_STRVAR(brotli_Compressor_finish_doc,
 "  brotli.error: If compression fails\n");
 
 static PyObject* brotli_Compressor_finish(brotli_Compressor *self) {
-  PyObject *ret = NULL;
-  std::vector<uint8_t> output;
-  BROTLI_BOOL ok = BROTLI_TRUE;
+  PyObject *ret;
 
   if (!self->enc) {
-    ok = BROTLI_FALSE;
-    goto end;
+    goto error;
   }
 
-  ok = compress_stream(self->enc, BROTLI_OPERATION_FINISH,
-                       &output, NULL, 0);
+  ret = compress_stream(self->enc, BROTLI_OPERATION_FINISH,
+                        NULL, 0);
 
-  if (ok) {
-    ok = BrotliEncoderIsFinished(self->enc);
+  if (ret == NULL || !BrotliEncoderIsFinished(self->enc)) {
+    goto error;
   }
+  goto final;
 
-end:
-  if (ok) {
-    ret = PyBytes_FromStringAndSize((char*)(output.empty() ? NULL : &output[0]), output.size());
-  } else {
-    PyErr_SetString(BrotliError, "BrotliEncoderCompressStream failed while finishing the stream");
-  }
-
+error:
+  PyErr_SetString(BrotliError,
+                  "BrotliEncoderCompressStream failed while finishing the stream");
+  ret = NULL;
+final:
   return ret;
 }
 

--- a/python/_brotli.cc
+++ b/python/_brotli.cc
@@ -281,39 +281,47 @@ static int lgblock_convertor(PyObject *o, int *lgblock) {
   return 1;
 }
 
-static BROTLI_BOOL compress_stream(BrotliEncoderState* enc, BrotliEncoderOperation op,
-                                   std::vector<uint8_t>* output,
-                                   uint8_t* input, size_t input_length) {
-  BROTLI_BOOL ok = BROTLI_TRUE;
-  Py_BEGIN_ALLOW_THREADS
-
+static PyObject* compress_stream(BrotliEncoderState* enc, BrotliEncoderOperation op,
+                                 uint8_t* input, size_t input_length) {
+  BROTLI_BOOL ok;
   size_t available_in = input_length;
   const uint8_t* next_in = input;
-  size_t available_out = 0;
-  uint8_t* next_out = NULL;
+  size_t available_out;
+  uint8_t* next_out;
+  BlocksOutputBuffer buffer = {.list=NULL};
+  PyObject *output;
 
-  while (ok) {
+  if (BlocksOutputBuffer_InitAndGrow(&buffer, &available_out, &next_out) < 0) {
+    goto error;
+  }
+
+  while (1) {
+    Py_BEGIN_ALLOW_THREADS
     ok = BrotliEncoderCompressStream(enc, op,
                                      &available_in, &next_in,
                                      &available_out, &next_out, NULL);
-    if (!ok)
+    Py_END_ALLOW_THREADS
+    if (!ok) {
+      goto error;
+    }
+
+    if (available_out == 0 && BrotliEncoderHasMoreOutput(enc)) {
+      if (BlocksOutputBuffer_Grow(&buffer, &available_out, &next_out) < 0) {
+        goto error;
+      }
+    } else if (available_in == 0) {
       break;
-
-    size_t buffer_length = 0; // Request all available output.
-    const uint8_t* buffer = BrotliEncoderTakeOutput(enc, &buffer_length);
-    if (buffer_length) {
-      (*output).insert((*output).end(), buffer, buffer + buffer_length);
     }
-
-    if (available_in || BrotliEncoderHasMoreOutput(enc)) {
-      continue;
-    }
-
-    break;
   }
 
-  Py_END_ALLOW_THREADS
-  return ok;
+  output = BlocksOutputBuffer_Finish(&buffer, available_out);
+  if (output != NULL) {
+    return output;
+  }
+
+error:
+  BlocksOutputBuffer_OnError(&buffer);
+  return NULL;
 }
 
 PyDoc_STRVAR(brotli_Compressor_doc,

--- a/setup.py
+++ b/setup.py
@@ -71,40 +71,33 @@ class BuildExt(build_ext):
             log.info("building '%s' extension", ext.name)
 
         c_sources = []
-        cxx_sources = []
         for source in ext.sources:
             if source.endswith('.c'):
                 c_sources.append(source)
-            else:
-                cxx_sources.append(source)
         extra_args = ext.extra_compile_args or []
 
         objects = []
-        for lang, sources in (('c', c_sources), ('c++', cxx_sources)):
-            if lang == 'c++':
-                if self.compiler.compiler_type == 'msvc':
-                    extra_args.append('/EHsc')
 
-            macros = ext.define_macros[:]
-            if platform.system() == 'Darwin':
-                macros.append(('OS_MACOSX', '1'))
-            elif self.compiler.compiler_type == 'mingw32':
-                # On Windows Python 2.7, pyconfig.h defines "hypot" as "_hypot",
-                # This clashes with GCC's cmath, and causes compilation errors when
-                # building under MinGW: http://bugs.python.org/issue11566
-                macros.append(('_hypot', 'hypot'))
-            for undef in ext.undef_macros:
-                macros.append((undef,))
+        macros = ext.define_macros[:]
+        if platform.system() == 'Darwin':
+            macros.append(('OS_MACOSX', '1'))
+        elif self.compiler.compiler_type == 'mingw32':
+            # On Windows Python 2.7, pyconfig.h defines "hypot" as "_hypot",
+            # This clashes with GCC's cmath, and causes compilation errors when
+            # building under MinGW: http://bugs.python.org/issue11566
+            macros.append(('_hypot', 'hypot'))
+        for undef in ext.undef_macros:
+            macros.append((undef,))
 
-            objs = self.compiler.compile(
-                sources,
-                output_dir=self.build_temp,
-                macros=macros,
-                include_dirs=ext.include_dirs,
-                debug=self.debug,
-                extra_postargs=extra_args,
-                depends=ext.depends)
-            objects.extend(objs)
+        objs = self.compiler.compile(
+            c_sources,
+            output_dir=self.build_temp,
+            macros=macros,
+            include_dirs=ext.include_dirs,
+            debug=self.debug,
+            extra_postargs=extra_args,
+            depends=ext.depends)
+        objects.extend(objs)
 
         self._built_objects = objects[:]
         if ext.extra_objects:
@@ -117,7 +110,7 @@ class BuildExt(build_ext):
 
         ext_path = self.get_ext_fullpath(ext.name)
         # Detect target language, if not provided
-        language = ext.language or self.compiler.detect_language(sources)
+        language = ext.language or self.compiler.detect_language(c_sources)
 
         self.compiler.link_shared_object(
             objects,
@@ -180,7 +173,7 @@ EXT_MODULES = [
     Extension(
         '_brotli',
         sources=[
-            'python/_brotli.cc',
+            'python/_brotli.c',
             'c/common/constants.c',
             'c/common/context.c',
             'c/common/dictionary.c',
@@ -267,8 +260,7 @@ EXT_MODULES = [
         ],
         include_dirs=[
             'c/include',
-        ],
-        language='c++'),
+        ]),
 ]
 
 TEST_SUITE = 'setup.get_test_suite'


### PR DESCRIPTION
Currently, the output buffer is a `std::vector<uint8_t>`.
When the buffer grows, resizing will cause unnecessary `memcpy()`.

This PR uses a list of bytes object to represent output buffer, can avoid the extra overhead of resizing.
In addition, C++ code can be removed, it's a pure C extension.

Please review the 11 commits one by one.

**May 2, 2021 update**:
- use some code improvements from https://bugs.python.org/issue41486
- refactoring to make the code more concise, reducing the chance of mistake during code maintenance 

Benchmarks:
```
The first column is output date size, the unit is MB.
The second and third columns are consumed time, in seconds.

size before   after
0    0.00006  0.00001
10   0.02449  0.02165
20   0.04640  0.03691
30   0.06695  0.05128
40   0.08199  0.06622
50   0.10581  0.08062
60   0.12336  0.09513
70   0.15077  0.11034
80   0.16498  0.12552
90   0.17981  0.13893
100  0.21600  0.15383
110  0.22965  0.17016
120  0.24485  0.18513
130  0.26064  0.19902
140  0.30751  0.21165
150  0.32188  0.22795
160  0.34317  0.24160
170  0.35872  0.25647
180  0.36515  0.27271
190  0.38189  0.28756
200  0.39475  0.30176
```

```
The first column is output date size, the unit is KB.

size before   after
0    0.00672  0.00669
20   0.00007  0.00011
40   0.00010  0.00013
60   0.00016  0.00017
80   0.00032  0.00024
100  0.00034  0.00028
120  0.00041  0.00032
140  0.00053  0.00037
160  0.00048  0.00043
180  0.00054  0.00057
200  0.00052  0.00053
220  0.00056  0.00071
240  0.00062  0.00062
260  0.00081  0.00071
280  0.00085  0.00090
300  0.00093  0.00090
320  0.00093  0.00093
340  0.00098  0.00091
360  0.00104  0.00106
380  0.00103  0.00142
400  0.00105  0.00114
420  0.00121  0.00116
440  0.00118  0.00128
460  0.00123  0.00137
480  0.00122  0.00178
500  0.00148  0.00142
```

Benchmark code:
```python
from time import perf_counter
from brotli import *

MB = 1024*1024
KB = 1024

for i in range(0, 200*MB+1, 10*MB):
    dat1 = i * b'a'
    dat2 = compress(dat1)
    
    t1 = perf_counter()
    dat3 = decompress(dat2)
    t2 = perf_counter()
    print(i//MB, '%.5f' % (t2-t1))
    
    assert dat1 == dat3
    
for i in range(0, 500*KB+1, 20*KB):
    dat1 = i * b'a'
    dat2 = compress(dat1)
    
    t1 = perf_counter()
    dat3 = decompress(dat2)
    t2 = perf_counter()
    print(i//KB, '%.5f' % (t2-t1))
    
    assert dat1 == dat3
```