### PR TITLE
Fix vla-parameter warnings

### DIFF
--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -2033,8 +2033,10 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 }
 
 BrotliDecoderResult BrotliDecoderDecompress(
-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
-    uint8_t* decoded_buffer) {
+    size_t encoded_size,
+    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
+    size_t* decoded_size,
+    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]) {
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -1470,8 +1470,9 @@ static size_t MakeUncompressedStream(
 
 BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
-    const uint8_t* input_buffer, size_t* encoded_size,
-    uint8_t* encoded_buffer) {
+    const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
+    size_t* encoded_size,
+    uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]) {
   BrotliEncoderState* s;
   size_t out_size = *encoded_size;
   const uint8_t* input_start = input_buffer;


### PR DESCRIPTION
e.g.
ERROR: /home/peter/brotli/BUILD:113:11: Compiling c/dec/decode.c failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 31 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
c/dec/decode.c:2036:41: error: argument 2 of type 'const uint8_t *' {aka 'const unsigned char *'} declared as a pointer [-Werror=vla-parameter]
 2036 |     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
      |                          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
In file included from c/dec/decode.c:7:
bazel-out/k8-opt/bin/_virtual_includes/brotli_inc/brotli/decode.h:204:19: note: previously declared as a variable length array 'const uint8_t[*decoded_size]' {aka 'const unsigned char[*decoded_size]'}
  204 |     const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
c/dec/decode.c:2037:14: error: argument 4 of type 'uint8_t *' {aka 'unsigned char *'} declared as a pointer [-Werror=vla-parameter]
 2037 |     uint8_t* decoded_buffer) {
      |     ~~~~~~~~~^~~~~~~~~~~~~~
In file included from c/dec/decode.c:7:
bazel-out/k8-opt/bin/_virtual_includes/brotli_inc/brotli/decode.h:206:13: note: previously declared as a variable length array 'uint8_t[encoded_size]' {aka 'unsigned char[encoded_size]'}
  206 |     uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors