### PR TITLE
Update buffer parameter types in encode and decode functions

### DIFF
--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -2032,9 +2032,12 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
   return ProcessCommandsInternal(1, s);
 }
 
-BrotliDecoderResult BrotliDecoderDecompress(
-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
-    uint8_t* decoded_buffer) {
+
+BROTLI_DEC_API BrotliDecoderResult BrotliDecoderDecompress(
+    size_t encoded_size,
+    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
+    size_t* decoded_size,
+    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]){
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -1468,10 +1468,12 @@ static size_t MakeUncompressedStream(
   return result;
 }
 
-BROTLI_BOOL BrotliEncoderCompress(
+
+BROTLI_ENC_API BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
-    const uint8_t* input_buffer, size_t* encoded_size,
-    uint8_t* encoded_buffer) {
+    const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
+    size_t* encoded_size,
+    uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]){
   BrotliEncoderState* s;
   size_t out_size = *encoded_size;
   const uint8_t* input_start = input_buffer;


### PR DESCRIPTION
brotil is used in the TianoCore project as a a git submodule.  Without this change, the compile fails on Fedora 34 with errors like 
brotli/c/dec/decode.c:2033:41: error: argument 2 of type ‘const uint8_t *’ {aka ‘const unsigned char *’} declared as a pointer [-Werror=vla-parameter]
 2033 |     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
