### PR TITLE
Fix for future versions of setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [build]
-build-base=bin
+build_base=bin
 
 [yapf]
 based_on_style=google


### PR DESCRIPTION
Starting python 3.10, the use of - instead of _ will get a warn (see https://bugs.gentoo.org/796281 for reference)

Signed-off-by: Marco Scardovi <marco@scardovi.com>