### PR TITLE
Release version 1.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SECURITY NOTE
 
-Please consider updating brotli to version 1.0.9 (latest).
+Please consider updating brotli to version 1.0.9 or later.
 
 Version 1.0.9 contains a fix to "integer overflow" problem. This happens when "one-shot" decoding API is used (or input chunk for streaming API is not limited), input size (chunk size) is larger than 2GiB, and input contains uncompressed blocks. After the overflow happens, `memcpy` is invoked with a gigantic `num` value, that will likely cause the crash.
 

--- a/c/common/version.h
+++ b/c/common/version.h
@@ -14,13 +14,13 @@
    BrotliEncoderVersion methods. */
 
 /* Semantic version, calculated as (MAJOR << 24) | (MINOR << 12) | PATCH */
-#define BROTLI_VERSION 0x1000009
+#define BROTLI_VERSION 0x100000a
 
 /* This macro is used by build system to produce Libtool-friendly soname. See
    https://www.gnu.org/software/libtool/manual/html_node/Libtool-versioning.html
  */
 
 /* ABI version, calculated as (CURRENT << 24) | (REVISION << 12) | AGE */
-#define BROTLI_ABI_VERSION 0x1009000
+#define BROTLI_ABI_VERSION 0x100a000
 
 #endif  /* BROTLI_COMMON_VERSION_H_ */


### PR DESCRIPTION
This is mostly needed due to #838, without which static linking is broken.
As Brotli is now part of JPEG XL, this is crucial for programs wanting to support the new file format.
The current workaround there is to use a vendored copy of brotli's master branch, which isn't really a good idea for a major standard like that.
Also note: https://github.com/google/brotli/issues/848#issuecomment-699607362