### PR TITLE
doc: default windows size is 24

### DIFF
--- a/docs/brotli.1
+++ b/docs/brotli.1
@@ -103,7 +103,7 @@ Conflicting or duplicate \fIoptions\fR are not allowed\.
   increase output verbosity
 .IP \(bu 2
 \fB\-w NUM\fP, \fB\-\-lgwin=NUM\fP:
-  set LZ77 window size (0, 10\-24) (default: 22); window size is
+  set LZ77 window size (0, 10\-24) (default: 24); window size is
   \fB(2**NUM \- 16)\fP; 0 lets compressor decide over the optimal value; bigger
   windows size improve density; decoder might require up to window size
   memory to operate


### PR DESCRIPTION
Proposed patch fixes default window size (`-w`, `--lgwin`) in the documentation.

Since #656 it got increased to 24, see https://github.com/google/brotli/blob/19d86fb9a60aa7034d4981b69a5b656f5b90017e/c/tools/brotli.c#L86