### PR TITLE
Fix: write success message to stdout instead of stderr

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -1059,9 +1059,9 @@ static BROTLI_BOOL CompressFile(Context* context, BrotliEncoderState* s) {
       if (!FlushOutput(context)) return BROTLI_FALSE;
       if (context->verbosity > 0) {
         context->end_time = clock();
-        fprintf(stderr, "Compressed ");
+        fprintf(stdout, "Compressed ");
         PrintFileProcessingProgress(context);
-        fprintf(stderr, "\n");
+        fprintf(stdout, "\n");
       }
       return BROTLI_TRUE;
     }


### PR DESCRIPTION
Minor fix: when brotli exits with `BROTLI_TRUE` it should write its message to `stdout` instead of `stderr`.