### PR TITLE
python: Use underscore separated keys in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [build]
-build-base=bin
+build_base=bin
 
 [yapf]
 based_on_style=google


### PR DESCRIPTION
setuptools has deprecated dash-separated keys:

```
Usage of dash-separated 'build-base' will not be supported in future versions. Please use the underscore name 'build_base' instead
```