### PR TITLE
Fix build errors for BrotliEncoder(De)Compress

### DIFF
--- a/c/include/brotli/decode.h
+++ b/c/include/brotli/decode.h
@@ -225,9 +225,9 @@ BROTLI_DEC_API void BrotliDecoderDestroyInstance(BrotliDecoderState* state);
  */
 BROTLI_DEC_API BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size,
-    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
+    const uint8_t *encoded_buffer,
     size_t* decoded_size,
-    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
+    uint8_t *decoded_buffer);
 
 /**
  * Decompresses the input stream to the output stream.

--- a/c/include/brotli/encode.h
+++ b/c/include/brotli/encode.h
@@ -357,9 +357,9 @@ BROTLI_ENC_API size_t BrotliEncoderMaxCompressedSize(size_t input_size);
  */
 BROTLI_ENC_API BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
-    const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
+    const uint8_t *input_buffer,
     size_t* encoded_size,
-    uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]);
+    uint8_t *encoded_buffer);
 
 /**
  * Compresses input stream to output stream.


### PR DESCRIPTION
With GCC 11.2 build errors like the following occur:

brotli/c/dec/decode.c:2033:41:
error: argument 2 of type ‘const uint8_t *’ {aka ‘const unsigned char *’}
declared as a pointer [-Werror=vla-parameter]
 2033 |     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
      |                          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
In file included from brotli/c/dec/decode.c:7:
./brotli/c/include/brotli/decode.h:206:13: note: previously declared as
a variable length array ‘uint8_t[encoded_size]’ {aka ‘unsigned char[encoded_size]’}
  206 |     uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Use consistent declarations.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>