### PR TITLE
Provide length-limited decompress methods

### DIFF
--- a/java/org/brotli/wrapper/dec/BUILD
+++ b/java/org/brotli/wrapper/dec/BUILD
@@ -101,3 +101,16 @@ java_test(
     test_class = "org.brotli.wrapper.dec.CornerCasesTest",
     runtime_deps = [":test_lib"],
 )
+
+java_test(
+    name = "LengthLimitedTest",
+    size = "large",
+    data = [
+        ":brotli_jni",  # Bazel JNI workaround
+    ],
+    jvm_flags = [
+        "-DBROTLI_JNI_LIBRARY=$(location :brotli_jni)",
+    ],
+    test_class = "org.brotli.wrapper.dec.LengthLimitedTest",
+    runtime_deps = [":test_lib"],
+)

--- a/java/org/brotli/wrapper/dec/Decoder.java
+++ b/java/org/brotli/wrapper/dec/Decoder.java
@@ -140,8 +140,25 @@ public class Decoder {
 
   /**
    * Decodes the given data buffer.
+   * @param data compressed data buffer to be decoded
+   * @return Array containing the decompressed data
+   * @throws IOException when input data is corrupt or the native brotli decoder could not be initialized
    */
   public static byte[] decompress(byte[] data) throws IOException {
+    return decompress(data, 0);
+  }
+
+
+  /**
+   * Decodes the given data buffer. Allows the caller to specify the maximum allowed decompressed length.
+   * Ensures that space complexity grows linearly with the {@code maxDecompressedLength}.
+   * @param data compressed data buffer to be decoded
+   * @param maxDecompressedLength maximum allowed length of the decoded data or 0 for any length
+   * @return Array containing the decompressed data
+   * @throws IOException when input data is corrupt or the native brotli decoder could not be initialized
+   * @throws IllegalArgumentException when the decompressed length exceeds {@code maxDecompressedLength}
+   */
+  public static byte[] decompress(byte[] data, int maxDecompressedLength) throws IOException {
     DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(data.length);
     ArrayList<byte[]> output = new ArrayList<byte[]>();
     int totalOutputSize = 0;
@@ -155,11 +172,14 @@ public class Decoder {
             break;
 
           case NEEDS_MORE_OUTPUT:
-            ByteBuffer buffer = decoder.pull();
+            ByteBuffer buffer = decoder.pull(maxDecompressedLength);
             byte[] chunk = new byte[buffer.remaining()];
             buffer.get(chunk);
             output.add(chunk);
             totalOutputSize += chunk.length;
+            if (maxDecompressedLength > 0 && buffer.remaining() + totalOutputSize > maxDecompressedLength) {
+              throw new IllegalArgumentException("Output length has exceeded expected length");
+            }
             break;
 
           case NEEDS_MORE_INPUT:
@@ -188,5 +208,64 @@ public class Decoder {
       offset += chunk.length;
     }
     return result;
+  }
+
+  /**
+   * Decodes the given data buffer. Allows the caller to specify the expected decompressed length when available.
+   * Ensures that space complexity grows linearly with the expected {@code decompressedLength}.
+   * @param data compressed data buffer to be decoded
+   * @param decompressedLength expected length of the decoded data
+   * @return Array containing the decompressed data
+   * @throws IOException when input data is corrupt or the native brotli decoder could not be initialized
+   * @throws IllegalArgumentException when the expected {@code decompressedLength} is not
+   *          equal to the actual decompressed length
+   */
+  public static byte[] decompressKnownLength(byte[] data, int decompressedLength) throws IOException {
+    if (decompressedLength <= 0) {
+      // Prevents specifying a length of 0 to circumvent length enforcement.
+      throw new IllegalArgumentException("provided decompressedLength must be > 0.");
+    }
+    DecoderJNI.Wrapper decoder = new DecoderJNI.Wrapper(data.length);
+    byte[] output = new byte[decompressedLength];
+    int outputRead = 0;
+    try {
+      decoder.getInputBuffer().put(data);
+      decoder.push(data.length);
+      while (decoder.getStatus() != DecoderJNI.Status.DONE) {
+        switch (decoder.getStatus()) {
+        case OK:
+          decoder.push(0);
+          break;
+
+        case NEEDS_MORE_OUTPUT:
+          ByteBuffer buffer = decoder.pull(decompressedLength);
+          int readLen = Math.min(buffer.remaining(), decompressedLength - outputRead);
+          buffer.get(output, outputRead, readLen);
+          outputRead += readLen;
+          if (buffer.remaining() > 0 && outputRead == decompressedLength) {
+            throw new IllegalArgumentException("Output length has exceeded expected length");
+          }
+          break;
+
+        case NEEDS_MORE_INPUT:
+          // Allow decoder to decode any outstanding data from the existing input buffer.
+          decoder.push(0);
+          // If decoder still needs more, input buffer was incomplete.
+          if (decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_INPUT) {
+            throw new IOException("corrupted input");
+          }
+          break;
+
+        default:
+          throw new IOException("corrupted input");
+        }
+      }
+    } finally {
+      decoder.destroy();
+    }
+    if (outputRead < decompressedLength) {
+      throw new IllegalArgumentException("Output length is less than expected length");
+    }
+    return output;
   }
 }

--- a/java/org/brotli/wrapper/dec/DecoderJNI.java
+++ b/java/org/brotli/wrapper/dec/DecoderJNI.java
@@ -15,7 +15,7 @@ import java.nio.ByteBuffer;
 public class DecoderJNI {
   private static native ByteBuffer nativeCreate(long[] context);
   private static native void nativePush(long[] context, int length);
-  private static native ByteBuffer nativePull(long[] context);
+  private static native ByteBuffer nativePull(long[] context, int length);
   private static native void nativeDestroy(long[] context);
   private static native boolean nativeAttachDictionary(long[] context, ByteBuffer dictionary);
 
@@ -100,6 +100,16 @@ public class DecoderJNI {
     }
 
     public ByteBuffer pull() {
+      return pull(0);
+    }
+
+    /**
+     * Pulls decompressed data from the decoder.
+     * @param length number of bytes that the caller is ready to pull from the decoder, 0 if any amount
+     *               could be handled.
+     * @return a buffer which has at most {@code length} bytes available.
+     */
+    public ByteBuffer pull(int length) {
       if (context[0] == 0) {
         throw new IllegalStateException("brotli decoder is already destroyed");
       }
@@ -107,7 +117,7 @@ public class DecoderJNI {
         throw new IllegalStateException("pulling output from decoder in " + lastStatus + " state");
       }
       fresh = false;
-      ByteBuffer result = nativePull(context);
+      ByteBuffer result = nativePull(context, length);
       parseStatus();
       return result;
     }

--- a/java/org/brotli/wrapper/dec/LengthLimitedTest.java
+++ b/java/org/brotli/wrapper/dec/LengthLimitedTest.java
@@ -1,0 +1,67 @@
+package org.brotli.wrapper.dec;
+
+import org.brotli.integration.BrotliJniTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnit4.class)
+public class LengthLimitedTest extends BrotliJniTestBase {
+
+  private static final byte[] COMPRESSED_DATA = {-117, 2, -128, 66, 82, 79, 84, 76, 73, 3};
+  private static final int ORIGINAL_DATA_LENGTH = 6; // "BROTLI" length
+
+  @Test
+  public void decompressKnownLength() throws IOException {
+    byte[] decompressedData = Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH);
+    assertEquals("BROTLI", new String(decompressedData, StandardCharsets.UTF_8));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void decompressKnownLengthDataTooBig() throws IOException {
+    Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void decompressKnownLengthDataTooSmall() throws IOException {
+    Decoder.decompressKnownLength(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void decompressKnownLengthZeroLength() throws IOException {
+    Decoder.decompressKnownLength(COMPRESSED_DATA, 0);
+  }
+
+  @Test
+  public void decompressMaxLengthExactLength() throws IOException {
+    byte[] decompressedData = Decoder.decompress(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH);
+    assertEquals("BROTLI", new String(decompressedData, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void decompressMaxLengthAllowedLength() throws IOException {
+    byte[] decompressedData = Decoder.decompress(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH + 5);
+    assertEquals("BROTLI", new String(decompressedData, StandardCharsets.UTF_8));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void decompressMaxLengthDisallowedLength() throws IOException {
+    Decoder.decompress(COMPRESSED_DATA, ORIGINAL_DATA_LENGTH - 2);
+  }
+
+  @Test
+  public void decompressMaxLengthAnyLength() throws IOException {
+    byte[] decompressedData = Decoder.decompress(COMPRESSED_DATA, 0);
+    assertEquals("BROTLI", new String(decompressedData, StandardCharsets.UTF_8));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void decompressMaxLengthNegativeLength() throws IOException {
+    Decoder.decompress(COMPRESSED_DATA, -1);
+  }
+}

--- a/java/org/brotli/wrapper/dec/decoder_jni.cc
+++ b/java/org/brotli/wrapper/dec/decoder_jni.cc
@@ -167,11 +167,17 @@ Java_org_brotli_wrapper_dec_DecoderJNI_nativePush(
  */
 JNIEXPORT jobject JNICALL
 Java_org_brotli_wrapper_dec_DecoderJNI_nativePull(
-    JNIEnv* env, jobject /*jobj*/, jlongArray ctx) {
+    JNIEnv* env, jobject /*jobj*/, jlongArray ctx, jint output_length) {
   jlong context[3];
   env->GetLongArrayRegion(ctx, 0, 3, context);
   DecoderHandle* handle = getHandle(reinterpret_cast<void*>(context[0]));
-  size_t data_length = 0;
+  size_t max_size = (size_t)-1;
+  if (output_length > max_size || output_length < 0) {
+    env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"),
+      "output_length exceeds size_t maximum or is negative.");
+    return NULL;
+  }
+  size_t data_length = (size_t)output_length;
   const uint8_t* data = BrotliDecoderTakeOutput(handle->state, &data_length);
   bool hasMoreOutput = !!BrotliDecoderHasMoreOutput(handle->state);
   if (hasMoreOutput) {

--- a/java/org/brotli/wrapper/dec/decoder_jni.h
+++ b/java/org/brotli/wrapper/dec/decoder_jni.h
@@ -53,7 +53,7 @@ Java_org_brotli_wrapper_dec_DecoderJNI_nativePush(
  */
 JNIEXPORT jobject JNICALL
 Java_org_brotli_wrapper_dec_DecoderJNI_nativePull(
-    JNIEnv* env, jobject /*jobj*/, jlongArray ctx);
+    JNIEnv* env, jobject /*jobj*/, jlongArray ctx, jint output_length);
 
 /**
  * Releases all used resources.


### PR DESCRIPTION
Provide length-limited decompress methods so that callers can control allocation sizes.

Motivation:
Limiting the size of buffer allocation can help mitigate the risks of compression bombs. In cases where these could be a legitimate attack vector, we should provide the library caller with the option of limiting the buffer size.

Changes:
 -  Add `decompressKnownLength` method to `Decoder.java` to allow for decompression of known-size payloads.
 -  Add `decompress` overload to `Decoder.java` which accepts a max size to allow for decompression of untrusted payloads with a maximum allowed size.
 -  Modify `DecoderJNI.java`, `decoder_jni.cc` and `decoder_jni.h` to allow users to specify the output buffer size.

Result:
Callers which believe that they have known-size payloads or want to limit decompressed data sizes can decompress those payloads in linear space complexity based on the expected/max-allowed size rather than unknown space complexity, based on the actual size.