### PR TITLE
Fix -Wstrict-prototypes warnings

### DIFF
--- a/c/common/dictionary.c
+++ b/c/common/dictionary.c
@@ -5897,7 +5897,7 @@ static BrotliDictionary kBrotliDictionary = {
 #endif
 };
 
-const BrotliDictionary* BrotliGetDictionary() {
+const BrotliDictionary* BrotliGetDictionary(void) {
   return &kBrotliDictionary;
 }
 

--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -2776,7 +2776,7 @@ const char* BrotliDecoderErrorString(BrotliDecoderErrorCode c) {
   }
 }
 
-uint32_t BrotliDecoderVersion() {
+uint32_t BrotliDecoderVersion(void) {
   return BROTLI_VERSION;
 }
 


### PR DESCRIPTION
Envoy builds brotli with -Werror, and these strict prototypes are picked up by newer versions of clang.