### PR TITLE
avoid array allocation in Encoder.Mode enum

### DIFF
--- a/java/org/brotli/wrapper/enc/Encoder.java
+++ b/java/org/brotli/wrapper/enc/Encoder.java
@@ -47,8 +47,11 @@ public class Encoder {
      */
     FONT;
 
+    // see: https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/
+    private static final Mode[] ALL_VALUES = values();
+
     public static Mode of(int value) {
-      return values()[value];
+      return ALL_VALUES[value];
     }
   }
 


### PR DESCRIPTION
Reference:

https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/