### PR TITLE
fuzz: make target resist allocation failures

### DIFF
--- a/c/fuzz/decode_fuzzer.c
+++ b/c/fuzz/decode_fuzzer.c
@@ -27,6 +27,11 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   size_t total_out = 0;
 
   BrotliDecoderState* state = BrotliDecoderCreateInstance(0, 0, 0);
+  if (!state) {
+    // OOM is out-of-scope here.
+    free(buffer);
+    return 0;
+  }
 
   if (addend == 0)
     addend = size;


### PR DESCRIPTION
So that fuzzing can go on with simulated allocation failures

cf https://github.com/google/oss-fuzz/pull/9902