### PR TITLE
setup.py: add long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,9 +276,14 @@ CMD_CLASS = {
     'build_ext': BuildExt,
 }
 
+with open("README.md", "r") as f:
+    README = f.read()
+
 setup(
     name=NAME,
     description=DESCRIPTION,
+    long_description=README,
+    long_description_content_type="text/markdown",
     version=VERSION,
     url=URL,
     author=AUTHOR,


### PR DESCRIPTION
twine (the tool we use to upload packages to PyPI) is currently failing if the long_description (used to render a project's page on PyPI website) is not set. Somehow it complains that it is not well formatted reStructuredText, but it's simply empty... This looks like a bug, or bad interaction between twince and setuptools, because the field is technically optional. Also see https://github.com/pypa/twine/issues/960 and https://github.com/pypa/twine/issues/908.

This issue is currently preventing the upload of newly built Brotli v1.1.0 Python wheels to PyPI: https://github.com/google/brotli-wheels/issues/18#issuecomment-1706910190

Anyway, we may well set the long_description to the content of the README.md file, as it's customary for python projects.