### PR TITLE
CMake: install relocatable shared libs for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,6 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   add_definitions(-DOS_FREEBSD)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_definitions(-DOS_MACOSX)
-  set(CMAKE_MACOS_RPATH TRUE)
-  set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 if(BROTLI_EMSCRIPTEN)


### PR DESCRIPTION
Remove hardcoded `CMAKE_INSTALL_NAME_DIR`, so that it's `@rpath` by default (default CMake behavior when cmake_minimum_required() is at least 3.0). `set(CMAKE_MACOS_RPATH TRUE)` is useless, it's the default value for CMake if cmake_minimum_required() is at least 3.0 as well, no need to hardcode this value.

If someone wants to change this behavior for a specific reason, it can be injected externally, no need to patch build files.