### PR TITLE
print help to stdout

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -1543,7 +1543,7 @@ int main(int argc, char** argv) {
     case COMMAND_INVALID:
     default:
       is_ok = (command == COMMAND_HELP);
-      PrintHelp(FileName(argv[0]), is_ok);
+      PrintHelp(FileName(argv[0]), !is_ok);
       break;
   }
 


### PR DESCRIPTION
According to [GNU coding standards](https://www.gnu.org/prep/standards/standards.html#g_t_002d_002dhelp) \`--help' should be printed to stdout. It makes sense as long help screen can be paged (\`$ prog --help | more`), searched and so on.
There is an issue with the paging here because when paged with less(1) it makes black screen and even leaving it is difficult. I understand that is the issue but I made it to acknowledge the problem.
