### PR TITLE
cbrotli: add pkg-config directive

### DIFF
--- a/go/cbrotli/cgo.go
+++ b/go/cbrotli/cgo.go
@@ -7,7 +7,5 @@ package cbrotli
 
 // Inform golang build system that it should link brotli libraries.
 
-// #cgo LDFLAGS: -lbrotlicommon
-// #cgo LDFLAGS: -lbrotlidec
-// #cgo LDFLAGS: -lbrotlienc
+// #cgo pkg-config: libbrotlicommon libbrotlidec libbrotlienc
 import "C"


### PR DESCRIPTION
Adds the pkg-config directive for `libbrotlicommon`, `libbrotlidec` and `libbrotlienc`. Without this change, building `cbrotli` may fail on some platforms because the include directories are not set correctly:
```
github.com/google/brotli/go/cbrotli
# github.com/google/brotli/go/cbrotli
vendor/github.com/google/brotli/go/cbrotli/reader.go:13:10: fatal error: 'brotli/decode.h' file not found
#include <brotli/decode.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
```