### PR TITLE
Fix C4334 warnings when building with MSVC

### DIFF
--- a/c/dec/decode.c
+++ b/c/dec/decode.c
@@ -217,7 +217,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode DecodeVarLenUint8(
         s->substate_decode_uint8 = BROTLI_STATE_DECODE_UINT8_LONG;
         return BROTLI_DECODER_NEEDS_MORE_INPUT;
       }
-      *value = (1U << *value) + bits;
+      *value = ((brotli_reg_t)1U << *value) + bits;
       s->substate_decode_uint8 = BROTLI_STATE_DECODE_UINT8_NONE;
       return BROTLI_DECODER_SUCCESS;
 
@@ -1136,7 +1136,7 @@ static BrotliDecoderErrorCode DecodeContextMap(brotli_reg_t context_map_size,
             h->context_index = context_index;
             return BROTLI_DECODER_NEEDS_MORE_INPUT;
           }
-          reps += 1U << code;
+          reps += (brotli_reg_t)1U << code;
           BROTLI_LOG_UINT(reps);
           if (context_index + reps > context_map_size) {
             return
@@ -1800,7 +1800,7 @@ static void CalculateDistanceLut(BrotliDecoderState* s) {
   brotli_reg_t npostfix = s->distance_postfix_bits;
   brotli_reg_t ndirect = s->num_direct_distance_codes;
   brotli_reg_t alphabet_size_limit = s->distance_hgroup.alphabet_size_limit;
-  brotli_reg_t postfix = 1u << npostfix;
+  brotli_reg_t postfix = (brotli_reg_t)1u << npostfix;
   brotli_reg_t j;
   brotli_reg_t bits = 1;
   brotli_reg_t half = 0;

--- a/c/enc/compound_dictionary.c
+++ b/c/enc/compound_dictionary.c
@@ -191,8 +191,8 @@ BROTLI_BOOL AttachPreparedDictionary(
   compound->chunk_offsets[index + 1] = compound->total_size;
   {
     uint32_t* slot_offsets = (uint32_t*)(&dictionary[1]);
-    uint16_t* heads = (uint16_t*)(&slot_offsets[1u << dictionary->slot_bits]);
-    uint32_t* items = (uint32_t*)(&heads[1u << dictionary->bucket_bits]);
+    uint16_t* heads = (uint16_t*)(&slot_offsets[(size_t)1u << dictionary->slot_bits]);
+    uint32_t* items = (uint32_t*)(&heads[(size_t)1u << dictionary->bucket_bits]);
     const void* tail = (void*)&items[dictionary->num_items];
     if (dictionary->magic == kPreparedDictionaryMagic) {
       compound->chunk_source[index] = (const uint8_t*)tail;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -1856,7 +1856,7 @@ size_t BrotliEncoderEstimatePeakMemoryUsage(int quality, int lgwin,
   if (params.quality == FAST_ONE_PASS_COMPRESSION_QUALITY ||
       params.quality == FAST_TWO_PASS_COMPRESSION_QUALITY) {
     size_t state_size = sizeof(BrotliEncoderState);
-    size_t block_size = BROTLI_MIN(size_t, input_size, (1ul << params.lgwin));
+    size_t block_size = BROTLI_MIN(size_t, input_size, ((size_t)1ul << params.lgwin));
     size_t hash_table_size =
         HashTableSize(MaxHashTableSize(params.quality), block_size);
     size_t hash_size =
@@ -1873,7 +1873,7 @@ size_t BrotliEncoderEstimatePeakMemoryUsage(int quality, int lgwin,
     size_t short_ringbuffer_size = (size_t)1 << params.lgblock;
     int ringbuffer_bits = ComputeRbBits(&params);
     size_t ringbuffer_size = input_size < short_ringbuffer_size ?
-        input_size : (1u << ringbuffer_bits) + short_ringbuffer_size;
+        input_size : ((size_t)1u << ringbuffer_bits) + short_ringbuffer_size;
     size_t hash_size[4] = {0};
     size_t metablock_size =
         BROTLI_MIN(size_t, input_size, MaxMetablockSize(&params));

--- a/c/enc/hash.h
+++ b/c/enc/hash.h
@@ -540,8 +540,8 @@ static BROTLI_INLINE void FindCompoundDictionaryMatch(
   const uint64_t hash_mask = (~((uint64_t)0U)) >> (64 - hash_bits);
 
   const uint32_t* slot_offsets = (uint32_t*)(&self[1]);
-  const uint16_t* heads = (uint16_t*)(&slot_offsets[1u << slot_bits]);
-  const uint32_t* items = (uint32_t*)(&heads[1u << bucket_bits]);
+  const uint16_t* heads = (uint16_t*)(&slot_offsets[(size_t)1u << slot_bits]);
+  const uint32_t* items = (uint32_t*)(&heads[(size_t)1u << bucket_bits]);
   const uint8_t* source = NULL;
 
   const size_t cur_ix_masked = cur_ix & ring_buffer_mask;
@@ -652,8 +652,8 @@ static BROTLI_INLINE size_t FindAllCompoundDictionaryMatches(
   const uint64_t hash_mask = (~((uint64_t)0U)) >> (64 - hash_bits);
 
   const uint32_t* slot_offsets = (uint32_t*)(&self[1]);
-  const uint16_t* heads = (uint16_t*)(&slot_offsets[1u << slot_bits]);
-  const uint32_t* items = (uint32_t*)(&heads[1u << bucket_bits]);
+  const uint16_t* heads = (uint16_t*)(&slot_offsets[(size_t)1u << slot_bits]);
+  const uint32_t* items = (uint32_t*)(&heads[(size_t)1u << bucket_bits]);
   const uint8_t* source = NULL;
 
   const size_t cur_ix_masked = cur_ix & ring_buffer_mask;


### PR DESCRIPTION
Currently, brotli emits [C4334 warnings](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334?view=msvc-170) about implicit widening of shift results when building Brotli with MSVC for 64-bit targets with at least warning level 3 enabled.

This PR addresses the warnings by adding casts where necessary to widen before shifting (which seemed like the correct solution for all of the cases).