### PR TITLE
Reduce fdiv's into fmul's

### DIFF
--- a/c/enc/block_splitter_inc.h
+++ b/c/enc/block_splitter_inc.h
@@ -129,7 +129,7 @@ static size_t FN(FindBlocks)(const DataType* data, const size_t length,
     }
     /* More blocks for the beginning. */
     if (byte_ix < 2000) {
-      block_switch_cost *= 0.77 + 0.00003 * (double)byte_ix;
+      block_switch_cost *= 0.77 + 0.000035 * (double)byte_ix;
     }
     for (k = 0; k < num_histograms; ++k) {
       cost[k] -= min_cost;

--- a/c/enc/block_splitter_inc.h
+++ b/c/enc/block_splitter_inc.h
@@ -118,6 +118,7 @@ static size_t FN(FindBlocks)(const DataType* data, const size_t length,
     size_t insert_cost_ix = symbol * num_histograms;
     double min_cost = 1e99;
     double block_switch_cost = block_switch_bitcost;
+    static const double threshold = 0.07 / 2000.0;
     size_t k;
     for (k = 0; k < num_histograms; ++k) {
       /* We are coding the symbol with entropy code k. */
@@ -129,7 +130,7 @@ static size_t FN(FindBlocks)(const DataType* data, const size_t length,
     }
     /* More blocks for the beginning. */
     if (byte_ix < 2000) {
-      block_switch_cost *= 0.77 + 0.000035 * (double)byte_ix;
+      block_switch_cost *= 0.77 + threshold * (double)byte_ix;
     }
     for (k = 0; k < num_histograms; ++k) {
       cost[k] -= min_cost;

--- a/c/enc/block_splitter_inc.h
+++ b/c/enc/block_splitter_inc.h
@@ -118,7 +118,8 @@ static size_t FN(FindBlocks)(const DataType* data, const size_t length,
     size_t insert_cost_ix = symbol * num_histograms;
     double min_cost = 1e99;
     double block_switch_cost = block_switch_bitcost;
-    static const double threshold = 0.07 / 2000.0;
+    static const size_t prologue_length = 2000;
+    static const double multiplier = 0.07 / 2000;
     size_t k;
     for (k = 0; k < num_histograms; ++k) {
       /* We are coding the symbol with entropy code k. */
@@ -129,8 +130,8 @@ static size_t FN(FindBlocks)(const DataType* data, const size_t length,
       }
     }
     /* More blocks for the beginning. */
-    if (byte_ix < 2000) {
-      block_switch_cost *= 0.77 + threshold * (double)byte_ix;
+    if (byte_ix < prologue_length) {
+      block_switch_cost *= 0.77 + multiplier * (double)byte_ix;
     }
     for (k = 0; k < num_histograms; ++k) {
       cost[k] -= min_cost;

--- a/c/enc/block_splitter_inc.h
+++ b/c/enc/block_splitter_inc.h
@@ -129,7 +129,7 @@ static size_t FN(FindBlocks)(const DataType* data, const size_t length,
     }
     /* More blocks for the beginning. */
     if (byte_ix < 2000) {
-      block_switch_cost *= 0.77 + 0.07 * (double)byte_ix / 2000;
+      block_switch_cost *= 0.77 + 0.00003 * (double)byte_ix;
     }
     for (k = 0; k < num_histograms; ++k) {
       cost[k] -= min_cost;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -441,7 +441,7 @@ static BROTLI_BOOL ShouldCompress(
       static const double kMinEntropy = 7.92;
       const double bit_cost_threshold =
           (double)bytes * kMinEntropy * invKSampleRate;
-      size_t t = (bytes + kSampleRate - 1) * invKSampleRate;
+      size_t t = (double)(bytes + kSampleRate - 1) * invKSampleRate;
       uint32_t pos = (uint32_t)last_flush_pos;
       size_t i;
       for (i = 0; i < t; i++) {

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -437,10 +437,11 @@ static BROTLI_BOOL ShouldCompress(
     if ((double)num_literals > 0.99 * (double)bytes) {
       uint32_t literal_histo[256] = { 0 };
       static const uint32_t kSampleRate = 13;
+      static const double invKSampleRate = 1.0 / 13.0;
       static const double kMinEntropy = 7.92;
       const double bit_cost_threshold =
-          (double)bytes * kMinEntropy / kSampleRate;
-      size_t t = (bytes + kSampleRate - 1) / kSampleRate;
+          (double)bytes * kMinEntropy * invKSampleRate;
+      size_t t = (bytes + kSampleRate - 1) * invKSampleRate;
       uint32_t pos = (uint32_t)last_flush_pos;
       size_t i;
       for (i = 0; i < t; i++) {

--- a/c/enc/literal_cost.c
+++ b/c/enc/literal_cost.c
@@ -121,7 +121,7 @@ static void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
          rapidly in the beginning of the file, perhaps because the beginning
          of the data is a statistical "anomaly". */
       if (i < 2000) {
-        lit_cost += 0.7 - ((double)(2000 - i) / 2000.0 * 0.35);
+        lit_cost += 0.7 - ((double)(2000 - i) * 0.000175);
       }
       cost[i] = (float)lit_cost;
     }

--- a/c/enc/literal_cost.c
+++ b/c/enc/literal_cost.c
@@ -106,6 +106,7 @@ static void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
       size_t utf8_pos = UTF8Position(last_c, c, max_utf8);
       size_t masked_pos = (pos + i) & mask;
       size_t histo = histogram[256 * utf8_pos + data[masked_pos]];
+      static const double threshold = 0.35 / 2000.0;
       double lit_cost;
       if (histo == 0) {
         histo = 1;
@@ -121,7 +122,7 @@ static void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
          rapidly in the beginning of the file, perhaps because the beginning
          of the data is a statistical "anomaly". */
       if (i < 2000) {
-        lit_cost += 0.7 - ((double)(2000 - i) * 0.000175);
+        lit_cost += 0.7 - ((double)(2000 - i) * threshold);
       }
       cost[i] = (float)lit_cost;
     }

--- a/c/enc/literal_cost.c
+++ b/c/enc/literal_cost.c
@@ -106,7 +106,8 @@ static void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
       size_t utf8_pos = UTF8Position(last_c, c, max_utf8);
       size_t masked_pos = (pos + i) & mask;
       size_t histo = histogram[256 * utf8_pos + data[masked_pos]];
-      static const double threshold = 0.35 / 2000.0;
+      static const size_t prologue_length = 2000;
+      static const double multiplier = 0.35 / 2000;
       double lit_cost;
       if (histo == 0) {
         histo = 1;
@@ -121,8 +122,8 @@ static void EstimateBitCostsForLiteralsUTF8(size_t pos, size_t len, size_t mask,
          Perhaps because the entropy source is changing its properties
          rapidly in the beginning of the file, perhaps because the beginning
          of the data is a statistical "anomaly". */
-      if (i < 2000) {
-        lit_cost += 0.7 - ((double)(2000 - i) * threshold);
+      if (i < prologue_length) {
+        lit_cost += 0.35 + multiplier * (double)i;
       }
       cost[i] = (float)lit_cost;
     }


### PR DESCRIPTION
Provides small speedup on microarchitectures where the floating point divide is slower than the floating point multiply.

As measured on an Ampere Altra, I see about +0.5% depending on the input.

```
$ ./brotli.old -fvk -w 0 enwik8.xhtml
Compressed [enwik8.xhtml]: 95.367 MiB -> 24.549 MiB in 237.92 sec

$ ./brotli.new -fvk -w 0 enwik8.xhtml
Compressed [enwik8.xhtml]: 95.367 MiB -> 24.549 MiB in 236.72 sec
```