### PR TITLE
python - link statically against vc_redist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,12 @@ class BuildExt(build_ext):
       # This clashes with GCC's cmath, and causes compilation errors when
       # building under MinGW: http://bugs.python.org/issue11566
       macros.append(('_hypot', 'hypot'))
+    elif self.compiler.compiler_type == 'msvc':
+      # msvc links dynamicall to vc_runtime140.dll,
+      # which isn't installed by default on Windows 10+
+      # Therefore it should be statically linked
+      extra_args.append("/MT")
+    
     for undef in ext.undef_macros:
       macros.append((undef,))
 


### PR DESCRIPTION
This PR makes the python setup link against vc_runtime statically if msvc is used as compiler.
As cibuildwheel uses msvc on Windows, this PR solves #782 for good.
#782 is still an active issue and was closed despite it not being solved,
besides basically forcing all dependents to have to write about Windows users having to vc_redist. 