### PR TITLE
Update bro.py: Fix undefined name in Python code

### DIFF
--- a/python/bro.py
+++ b/python/bro.py
@@ -165,7 +165,7 @@ def main(args=None):
         # redirect the write according to symlink.
         if os.path.exists(options.outfile) and not options.force:
             parser.error(('Target --outfile=%s already exists, '
-                          'but --force was not requested.') % (outfile,))
+                          'but --force was not requested.') % (options.outfile,))
         outfile = open(options.outfile, 'wb')
         did_open_outfile = True
     else:


### PR DESCRIPTION
`outfile` is used before it is defined on the following line so use `options.outfile` instead.

% `ruff check`
```
Error: python/bro.py:168:64: F821 Undefined name `outfile`
```