### PR TITLE
cmake: fix man page install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,11 +384,11 @@ endif()  # BROTLI_BUNDLED_MODE
 
 if (BROTLI_BUILD_TOOLS)
   install(FILES "docs/brotli.1"
-    DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man1")
+    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
 endif()
 
 install(FILES docs/constants.h.3 docs/decode.h.3 docs/encode.h.3 docs/types.h.3
-  DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man3")
+  DESTINATION "${CMAKE_INSTALL_MANDIR}/man3")
 
 if (ENABLE_COVERAGE STREQUAL "yes")
   setup_target_for_coverage(coverage test coverage)


### PR DESCRIPTION
To not use a prefix-less absolute path with
`cmake --install <d> --prefix <path>`.

According to CMake docs about `_FULL_` variables:
"These variables shouldn't be used in install() commands as they do
not work with the cmake --install command's --prefix option, or with
the cpack installer generators."

Ref: https://cmake.org/cmake/help/v4.2/module/GNUInstallDirs.html

Follow-up to cff58032160406c170a3dc319ad6e7b288cafcc0 #1084
