### PR TITLE
[setup.py] Use PEP625-compliant lowercase 'brotli' package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ class BuildExt(build_ext):
         )
 
 
-NAME = "Brotli"
+NAME = "brotli"
 
 VERSION = get_version()
 


### PR DESCRIPTION
PyPI now requires that wheel filenames and metadata use normalized package names following PEP 625. Modern build tooling automatically normalize this, however this does not happen for old python versions (e.g. 2.7, 3.6, 3.7) which makes their upload fail. I had to apply the same patch to the v1.2.0 release be able to upload all the python wheels to PyPI, see:

https://github.com/google/brotli/issues/1327#issuecomment-3491479583

https://github.com/google/brotli-wheels/commit/ca4fed169bb72d09d0263feb34853247da9f4a45

It makes more sense to have this in here and get rid of the patch, regardless of when we drop support for those EOL pythons.