### PR TITLE
Lint Python code with ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,11 +40,16 @@ jobs:
     - name: Install tools
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install buildifier typos-cli
+        brew install buildifier ruff typos-cli
 
     - name: Check typos
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         ./scripts/check_typos.sh
+
+    - name: Lint Python code
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        ruff check
 
     # TODO(eustas): run buildifier

--- a/research/brotlidump.py
+++ b/research/brotlidump.py
@@ -8,6 +8,7 @@ I found the following issues with the Brotli format:
 - The block type code is useless if NBLTYPES==2, you would only need 1 symbol
   anyway, so why don't you just switch to "the other" type?
 """
+# ruff: noqa
 import struct
 from operator import itemgetter, methodcaller
 from itertools import accumulate, repeat


### PR DESCRIPTION
An extremely fast Python linter and code formatter, written in Rust. -- https://docs.astral.sh/ruff
* ⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8), isort, and [Black](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)
* 📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations of popular Flake8 plugins, like flake8-bugbear

% `ruff check --statistics`
```
85	E701	[ ] multiple-statements-on-one-line-colon
 4	F401	[*] unused-import
 2	E741	[ ] ambiguous-variable-name
 2	F841	[ ] unused-variable
Found 93 errors.
```
% `ruff check --ignore=E701,E741,F401,F841`
```
All checks passed!
```
% `ruff rule F841`
# unused-variable (F841)

Derived from the **Pyflakes** linter.

Fix is sometimes available.

## What it does
Checks for the presence of unused variables in function scopes.

## Why is this bad?
A variable that is defined but not used is likely a mistake, and should
be removed to avoid confusion.

If a variable is intentionally defined-but-not-used, it should be
prefixed with an underscore, or some other value that adheres to the
[`lint.dummy-variable-rgx`] pattern.

## Example
```python
def foo():
    x = 1
    y = 2
    return x
```

Use instead:
```python
def foo():
    x = 1
    return x
```

## Fix safety

This rule's fix is marked as unsafe because removing an unused variable assignment may
delete comments that are attached to the assignment.

## See also

This rule does not apply to bindings in unpacked assignments (e.g. `x, y = 1, 2`). See
[`unused-unpacked-variable`][RUF059] for this case.

## Options
- `lint.dummy-variable-rgx`

[RUF059]: https://docs.astral.sh/ruff/rules/unused-unpacked-variable/
