### PR TITLE
enc/dec: harden integer overflow checks in size computations (defense-in-depth)

### DIFF
--- a/c/dec/state.c
+++ b/c/dec/state.c
@@ -167,9 +167,20 @@ BROTLI_BOOL BrotliDecoderHuffmanTreeGroupInit(BrotliDecoderState* s,
      This number is discovered "unlimited" "enough" calculator; it is actually
      a wee bigger than required in several cases (especially for alphabets with
      less than 16 symbols). */
+  /* defense-in-depth: each step of the size cascade can wrap size_t under
+     hypothetical caller / metablock values that bypass the parse-time caps. */
+  if (alphabet_size_limit > SIZE_MAX - 376) return BROTLI_FALSE;
   const size_t max_table_size = alphabet_size_limit + 376;
+  if (max_table_size != 0 &&
+      ntrees > SIZE_MAX / sizeof(HuffmanCode) / max_table_size) {
+    return BROTLI_FALSE;
+  }
   const size_t code_size = sizeof(HuffmanCode) * ntrees * max_table_size;
+  if (ntrees != 0 && ntrees > SIZE_MAX / sizeof(HuffmanCode*)) {
+    return BROTLI_FALSE;
+  }
   const size_t htree_size = sizeof(HuffmanCode*) * ntrees;
+  if (code_size > SIZE_MAX - htree_size) return BROTLI_FALSE;
   /* Pointer alignment is, hopefully, wider than sizeof(HuffmanCode). */
   HuffmanCode** p = (HuffmanCode**)BROTLI_DECODER_ALLOC(s,
       code_size + htree_size);

--- a/c/enc/block_encoder_inc.h
+++ b/c/enc/block_encoder_inc.h
@@ -15,6 +15,11 @@ static void FN(BuildAndStoreEntropyCodes)(MemoryManager* m, BlockEncoder* self,
     const HistogramType* histograms, const size_t histograms_size,
     const size_t alphabet_size, HuffmanTree* tree,
     size_t* storage_ix, uint8_t* storage) {
+  /* defense-in-depth: refuse if histograms_size * histogram_length_ wraps size_t */
+  if (self->histogram_length_ != 0 &&
+      histograms_size > SIZE_MAX / self->histogram_length_) {
+    return;
+  }
   const size_t table_size = histograms_size * self->histogram_length_;
   self->depths_ = BROTLI_ALLOC(m, uint8_t, table_size);
   self->bits_ = BROTLI_ALLOC(m, uint16_t, table_size);

--- a/c/enc/block_splitter.c
+++ b/c/enc/block_splitter.c
@@ -57,6 +57,13 @@ static void CopyLiteralsToByteArray(const Command* cmds,
   size_t i;
   for (i = 0; i < num_commands; ++i) {
     size_t insert_len = cmds[i].insert_len_;
+    /* defense-in-depth: refuse insert_len that wraps size_t when added to
+       from_pos. cmds[i].insert_len_ is encoder-internal and bounded by the
+       command builder; this is a defensive narrowing for hypothetical reuse
+       with caller-controlled insert_len. */
+    if (insert_len > (size_t)0 - from_pos) {
+      return;
+    }
     if (from_pos + insert_len > mask) {
       size_t head_size = mask + 1 - from_pos;
       memcpy(literals + pos, data + from_pos, head_size);

--- a/c/enc/block_splitter_inc.h
+++ b/c/enc/block_splitter_inc.h
@@ -205,6 +205,8 @@ static void FN(ClusterBlocks)(MemoryManager* m,
                               const size_t num_blocks,
                               uint8_t* block_ids,
                               BlockSplit* split) {
+  /* defense-in-depth: refuse if num_blocks + 4 * HISTOGRAMS_PER_BATCH wraps. */
+  if (num_blocks > SIZE_MAX - 4 * HISTOGRAMS_PER_BATCH) return;
   uint32_t* histogram_symbols = BROTLI_ALLOC(m, uint32_t, num_blocks);
   uint32_t* u32 =
       BROTLI_ALLOC(m, uint32_t, num_blocks + 4 * HISTOGRAMS_PER_BATCH);
@@ -451,6 +453,9 @@ static void FN(SplitByteVector)(MemoryManager* m,
     uint8_t* block_ids = BROTLI_ALLOC(m, uint8_t, length);
     size_t num_blocks = 0;
     const size_t bitmaplen = (num_histograms + 7) >> 3;
+    /* defense-in-depth: refuse if either multiplication wraps size_t. */
+    if (num_histograms != 0 && data_size > SIZE_MAX / num_histograms) return;
+    if (bitmaplen     != 0 && length    > SIZE_MAX / bitmaplen)     return;
     double* insert_cost = BROTLI_ALLOC(m, double, data_size * num_histograms);
     double* cost = BROTLI_ALLOC(m, double, num_histograms);
     uint8_t* switch_signal = BROTLI_ALLOC(m, uint8_t, length * bitmaplen);


### PR DESCRIPTION
## Summary

This PR adds defense-in-depth Integer Overflow / size_t wrap checks at five
size-computation sites in brotli's encoder and decoder. The checks are
defensive: triggering the underlying issues from a normal caller path is not
currently demonstrated. The motivation is to reduce the defense-in-depth gap
and to match the hardening style already used in surrounding code (e.g. early
returns on `BROTLI_DECODER_ALLOC` failures followed by buffer/length resets).

The cluster was identified by an external multi-perspective code review
(architect / defender / attacker perspectives) followed by static audit
against the current decoder/encoder caps. No exploit path was needed for
this defensive hardening.

## Sites covered

| # | File:Line | Issue summary | Fix style |
|---|-----------|---------------|-----------|
| 1 | `c/enc/block_encoder_inc.h:18` | `histograms_size * histogram_length_` not checked for size_t overflow before allocating `depths_` / `bits_` | Multiplication overflow guard |
| 2 | `c/dec/state.c:157` | `sizeof(HuffmanCode) * ntrees * max_table_size + htree_size` cascades arithmetic without intermediate checks | Addition + multiplication guards |
| 3 | `c/enc/block_splitter.c:59` | `from_pos + insert_len > mask` performs the addition before the bound check, so wrap can bypass the split logic | Pre-check `insert_len` against the available tail |
| 4 | `c/enc/block_splitter_inc.h:457` | `data_size * num_histograms` and `length * bitmaplen` allocated without overflow guards | Multiplication overflow guards |
| 5 | `c/enc/block_splitter_inc.h:211` | `num_blocks + 4 * HISTOGRAMS_PER_BATCH` not checked; the result is used as both an allocation size and as an offset base | Addition overflow guard |

All five fixes are pure additions: when the input values would cause size_t
to wrap, the code returns early (or signals the existing out-of-memory /
format-error path that the surrounding code already handles). Behavior on
currently-reachable inputs is unchanged.

## Severity / impact (honest disclosure)

These are defense-in-depth changes. We have not demonstrated a reachable
exploit path under brotli's current decoder/encoder caps:

- `BROTLI_LARGE_MAX_WBITS = 30` (decoder window cap; 1 GB << INT_MAX)
- `BROTLI_BLOCK_SIZE_CAP = 1 << 24` (16 MiB metablock cap)
- `SHARED_BROTLI_MIN_DICTIONARY_WORD_LENGTH = 4` (dictionary word lower bound)
- `kRingBufferWriteAheadSlack = 542` (transform output slack)
- decoder `transform_idx` range checks already present in the parse path

Under those caps, the size-computation sites covered here are not reachable
from a normal caller / standard brotli stream. The sites become reachable if:

- a future change relaxes one of the caps, or
- a malformed metablock bypasses one of the parse-time validators, or
- a caller (encoder or decoder) drives the affected internal state through
  an unusual path not currently exercised.

In all three cases, the additions in this PR turn an undefined-behavior
size_t wrap into a clean early return, matching the rest of the codebase's
defensive style.

We therefore frame the changes as hardening rather than as fixes for
confirmed exploitability. CWE-190 and CWE-680 are listed because the
underlying primitives are integer overflow into allocation size.

## Compatibility

The added checks are pure additions. On all currently-reachable inputs the
new checks are not triggered and behavior is identical. On inputs that
would have wrapped size_t the code now returns early (encoder: no-op
return / decoder: BROTLI_FALSE), matching how the surrounding code already
handles `BROTLI_ALLOC` failure.

No public API or ABI change.

## Tests

Static analysis: each site mirrors the structure of an existing
overflow-aware site elsewhere in the codebase. We extracted the audit
trail from a multi-perspective review (architect / defender / attacker
perspectives) and verified each fix against the surrounding caps and
caller invariants.

Unit / harness tests: not added in this PR. The host environment used to
prepare the patch did not have a working C toolchain (no gcc / clang / cl
/ tcc on PATH), so we deferred ASan / UBSan binary verification. We're
happy to add minimal Edge-Case Test cases for each site (driven via the
encoder / decoder internal harness) in a follow-up before merge — please
let us know if maintainers prefer tests bundled in the same PR or as a
follow-up.

## Honest disclosure

- The audit was performed by a multi-perspective code review, not by a
  fuzzing campaign. No corpus / repro input is included.
- The attacker-perspective analysis classifies all 5 sites as
  "boundary defense-in-depth, not currently reachable from a standard
  brotli stream under the current caps".
- We have intentionally avoided "exploit" / "PoC" framing: there is no
  demonstrated end-to-end exploit, only an audit-level defense gap.
- Reproduction steps for each site would require driving the affected
  internal state (e.g. very large `histograms_size` × `histogram_length_`)
  which is not reachable from caller-controlled input under the current
  caps.

If maintainers prefer a different framing (e.g. split per-file, drop some
sites that are deemed unreachable even with cap relaxations, require
ASan-verified repros), we'll happily revise.

## References

- CWE-190 (Integer Overflow or Wraparound): https://cwe.mitre.org/data/definitions/190.html
- CWE-680 (Integer Overflow to Buffer Overflow): https://cwe.mitre.org/data/definitions/680.html
