### PR TITLE
ci: pin bazel-contrib/publish-to-bcr to full commit SHA

### DIFF
--- a/.github/workflows/publish_to_bcr.yaml
+++ b/.github/workflows/publish_to_bcr.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v2
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@c316f1611511a40423572303f66c80bb30bfe2f8 # main@c316f161
     with:
       tag_name: ${{ inputs.tag_name }}
       registry_fork: ${{ inputs.registry_fork }}


### PR DESCRIPTION
`publish_to_bcr.yaml` references `bazel-contrib/publish-to-bcr@v2`, but no `v2` tag exists in that repo — the reference currently resolves to HEAD of `main`. Pin to the explicit commit SHA to make the resolution deterministic and supply-chain safe:

  `@v2` → `@c316f1611511a40423572303f66c80bb30bfe2f8`

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).