### PR TITLE
fix(java): reject encoder push length exceeding input buffer capacity

### DIFF
--- a/java/org/brotli/wrapper/enc/EncoderJNI.java
+++ b/java/org/brotli/wrapper/enc/EncoderJNI.java
@@ -109,6 +109,9 @@ class EncoderJNI {
       if (length < 0) {
         throw new IllegalArgumentException("negative block length");
       }
+      if (length > inputBuffer.capacity()) {
+        throw new IllegalArgumentException("block length exceeds input buffer capacity");
+      }
       if (context[0] == 0) {
         throw new IllegalStateException("brotli encoder is already destroyed");
       }


### PR DESCRIPTION
`EncoderJNI.Wrapper.push(int length)` validates only `length < 0`. On the native side
`nativePush()` stores `input_last = input_length` with no upper bound, and the encoder
handle does not retain the input buffer's allocation size, so:

    new EncoderJNI.Wrapper(1, quality, lgwin, mode).push(Operation.PROCESS, 32)

makes `BrotliEncoderCompressStream` read `input_start[0..32]` from a one-byte
allocation — a heap out-of-bounds read.

This is the encoder-side counterpart of the decoder fix in 2dc2a5fe
("fix(java): reject decoder push length exceeding input buffer capacity"), which
added the same upper-bound check to `DecoderJNI.Wrapper.push()`.

Fix: reject a push length that exceeds the input buffer capacity in
`EncoderJNI.Wrapper.push()`, matching the decoder wrapper. Happy to add an
`EncoderJNITest` mirroring `DecoderJNITest` (rejection + valid round trip) if preferred.
