### PR TITLE
Fix Base64 position wrapping after 3 GiB

### DIFF
--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -514,6 +514,7 @@ static void WriteMetaBlockInternal(MemoryManager* m,
                                    int* dist_cache,
                                    size_t* storage_ix,
                                    uint8_t* storage) {
+  const uint32_t wrapped_last_flush_pos = WrapPosition(last_flush_pos);
   uint16_t last_bytes;
   uint8_t last_bytes_bits;
   ContextLut literal_context_lut = BROTLI_CONTEXT_LUT(literal_context_mode);
@@ -532,7 +533,7 @@ static void WriteMetaBlockInternal(MemoryManager* m,
        CreateBackwardReferences is now unused. */
     memcpy(dist_cache, saved_dist_cache, 4 * sizeof(dist_cache[0]));
     BrotliStoreUncompressedMetaBlock(is_last, data,
-                                     (size_t)last_flush_pos, mask, bytes,
+                                     wrapped_last_flush_pos, mask, bytes,
                                      storage_ix, storage);
     return;
   }
@@ -541,13 +542,13 @@ static void WriteMetaBlockInternal(MemoryManager* m,
   last_bytes = (uint16_t)((storage[1] << 8) | storage[0]);
   last_bytes_bits = (uint8_t)(*storage_ix);
   if (params->quality <= MAX_QUALITY_FOR_STATIC_ENTROPY_CODES) {
-    BrotliStoreMetaBlockFast(m, data, (size_t)last_flush_pos,
+    BrotliStoreMetaBlockFast(m, data, wrapped_last_flush_pos,
                              bytes, mask, is_last, params,
                              commands, num_commands,
                              storage_ix, storage);
     if (BROTLI_IS_OOM(m)) return;
   } else if (params->quality < MIN_QUALITY_FOR_BLOCK_SPLIT) {
-    BrotliStoreMetaBlockTrivial(m, data, (size_t)last_flush_pos,
+    BrotliStoreMetaBlockTrivial(m, data, wrapped_last_flush_pos,
                                 bytes, mask, is_last, params,
                                 commands, num_commands,
                                 storage_ix, storage);
@@ -564,18 +565,18 @@ static void WriteMetaBlockInternal(MemoryManager* m,
             BROTLI_ALLOC(m, uint32_t, 32 * (BROTLI_MAX_STATIC_CONTEXTS + 1));
         if (BROTLI_IS_OOM(m) || BROTLI_IS_NULL(arena)) return;
         DecideOverLiteralContextModeling(
-            data, (size_t)last_flush_pos, bytes, mask, params->quality,
+            data, wrapped_last_flush_pos, bytes, mask, params->quality,
             params->size_hint, &num_literal_contexts,
             &literal_context_map, arena);
         BROTLI_FREE(m, arena);
       }
-      BrotliBuildMetaBlockGreedy(m, data, (size_t)last_flush_pos, mask,
+      BrotliBuildMetaBlockGreedy(m, data, wrapped_last_flush_pos, mask,
           base64_regions, num_base64_regions,
           prev_byte, prev_byte2, literal_context_lut, num_literal_contexts,
           literal_context_map, commands, num_commands, &mb);
       if (BROTLI_IS_OOM(m)) return;
     } else {
-      BrotliBuildMetaBlock(m, data, (size_t)last_flush_pos, mask,
+      BrotliBuildMetaBlock(m, data, wrapped_last_flush_pos, mask,
                            base64_regions, num_base64_regions,
                            &block_params,
                            prev_byte, prev_byte2,
@@ -590,7 +591,7 @@ static void WriteMetaBlockInternal(MemoryManager* m,
          for "Large Window Brotli" (32-bit). */
       BrotliOptimizeHistograms(block_params.dist.alphabet_size_limit, &mb);
     }
-    BrotliStoreMetaBlock(m, data, (size_t)last_flush_pos, bytes, mask,
+    BrotliStoreMetaBlock(m, data, wrapped_last_flush_pos, bytes, mask,
                          prev_byte, prev_byte2,
                          is_last,
                          &block_params,
@@ -608,7 +609,7 @@ static void WriteMetaBlockInternal(MemoryManager* m,
     storage[1] = (uint8_t)(last_bytes >> 8);
     *storage_ix = last_bytes_bits;
     BrotliStoreUncompressedMetaBlock(is_last, data,
-                                     (size_t)last_flush_pos, mask,
+                                     wrapped_last_flush_pos, mask,
                                      bytes, storage_ix, storage);
   }
 }


### PR DESCRIPTION
Base64 regions are recorded in Brotli's wrapped ring-buffer coordinate space,
but `WriteMetaBlockInternal()` currently passes the unwrapped 64-bit
`last_flush_pos` to the metablock and storage helpers. Once a streaming input
reaches the 3 GiB position-wrap boundary, a newly detected Base64 region near
the wrapped 1 GiB position appears to be behind the unwrapped current position.
It is consequently mapped to literal offset zero, and the Base64 histogram is
applied to unrelated bytes at the start of the metablock.

The encoder reports success, but the official decoder rejects the resulting
stream with `BROTLI_DECODER_ERROR_FORMAT_PADDING_2`.

This change restores the wrapped `last_flush_pos` used before Base64 mode was
introduced and passes that consistent coordinate to the ring-buffer,
metablock, and storage helpers.

The defect is limited to the opt-in `BROTLI_PARAM_BASE64_MODE` and streams that
cross the 3 GiB internal position boundary. It is distinct from #1509 and the
histogram-count fix in `0d1f629`; current master after that fix still reproduces
this position mismatch.

Validation on current master `8e10eeb3378f6c459dbaf033ca6727e9816afccb`:

- A constant-memory public streaming-API reproducer round-trips the crafted
  stream one 1 MiB block below the boundary.
- The same reproducer fails deterministically at exactly 3 GiB on untouched
  source and round-trips after this change.
- The zero-offset control and both boundary controls pass under ASan/UBSan.
- The complete CMake/CTest matrix passes, 73/73.
- `git diff --check` passes.
