### PR TITLE
Fix out-of-bounds write in ParseParams for empty-string arguments

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -301,11 +301,6 @@ static Command ParseParams(Context* params) {
        contain pointers to strings"; NULL and 0-length are not forbidden. */
     size_t arg_len = arg ? strlen(arg) : 0;
 
-    if (arg_len == 0) {
-      params->not_input_indices[next_option_index++] = i;
-      continue;
-    }
-
     /* Too many options. The expected longest option list is:
        "-q 0 -w 10 -o f -D d -S b -d -f -k -n -v -K --", i.e. 17 items in total.
        This check is an additional guard that is never triggered, but provides
@@ -313,6 +308,11 @@ static Command ParseParams(Context* params) {
     if (next_option_index > (MAX_OPTIONS - 2)) {
       fprintf(stderr, "too many options passed\n");
       return COMMAND_INVALID;
+    }
+
+    if (arg_len == 0) {
+      params->not_input_indices[next_option_index++] = i;
+      continue;
     }
 
     /* Input file entry. */


### PR DESCRIPTION
# Fix stack buffer overflow in `ParseParams` for empty-string CLI arguments

Fixes #1508.

## Problem

`ParseParams` in `c/tools/brotli.c` records every non-input-file argument index into the fixed-size array `params->not_input_indices[MAX_OPTIONS]` (24 elements). The "too many options" bounds check (`next_option_index > (MAX_OPTIONS - 2)`) runs *after* the `arg_len == 0` branch, so empty-string arguments are recorded *before* the guard is reached and can write past the end of the array.

With 25+ empty-string arguments (`brotli "" "" ...`), `next_option_index` exceeds 23 and `not_input_indices[24]` writes out of bounds. On a plain build this corrupts the `Context` struct on the stack and crashes (SIGSEGV reproduced locally); with ASan it reports a stack-buffer-overflow.

## Reproduction

```
args=()
for ((k=0; k<500; k++)); do args+=(""); done
./brotli "${args[@]}"
```

Before: crashes with a stack-buffer-overflow / segfault.
After: prints `too many options passed` and exits with `COMMAND_INVALID`.

## Fix

Move the bounds check to the top of the argument loop so it guards every write to `not_input_indices`, including the empty-string path. The check is documented as never triggering for valid invocations, so valid usage is unaffected.

## Verification

- Reproduced the crash with 500 empty-string args on the unpatched build (exit 139 / SIGSEGV).
- Patched build prints `too many options passed`, exits 1, no crash.
- Round-trip compression/decompression sanity check still passes.