### PR TITLE
cli: preserve sub-second mtime on the BSDs (fixes #1515)

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -79,6 +79,9 @@ static int ms_open(const char* filename, int oflag, int pmode) {
 #define HAVE_UTIMENSAT 1
 #elif defined(_ATFILE_SOURCE)
 #define HAVE_UTIMENSAT 1
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || \
+    defined(__DragonFly__)
+#define HAVE_UTIMENSAT 1
 #else
 #define HAVE_UTIMENSAT 0
 #endif


### PR DESCRIPTION
### Fixes #1515

`HAVE_UTIMENSAT` in `c/tools/brotli.c` is only set to 1 when
`_POSIX_C_SOURCE >= 200809L` or `_ATFILE_SOURCE` is defined:

```c
#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
#define HAVE_UTIMENSAT 1
#elif defined(_ATFILE_SOURCE)
#define HAVE_UTIMENSAT 1
#else
#define HAVE_UTIMENSAT 0
#endif
```

FreeBSD, OpenBSD, NetBSD and DragonFly BSD ship `utimensat()` / `futimens()`
and nanosecond-resolution `struct stat` timestamps, but do **not** define
either feature macro by default. So on those systems the CLI takes the
`utime()` fallback and the copied mtime is truncated to whole seconds — as
reported in #1515, where the `.br` output lands on `…​.000000000` next to a
source with real sub-second precision (`.gz` / `.zst` keep it).

`#891` / `#992` added the nanosecond path but the platform ladder never got a
BSD branch.

### Change

Add an explicit `elif` for the four BSDs. The existing non-Apple
`ATIME_NSEC` / `MTIME_NSEC` macros already use the `st_atim` / `st_mtim`
spelling those systems expose, so nothing else changes. Purely additive —
Linux / macOS / Windows are untouched.

### Testing

The preprocessor selection is verified with a extracted copy of the ladder:
`-D__FreeBSD__`, `-D__OpenBSD__`, `-D__NetBSD__`, `-D__DragonFly__` each yield
`HAVE_UTIMENSAT=1`; the bare case (no POSIX/ATFILE macro) still yields `0`.
CLI still builds clean (clang, `cmake -GNinja`).

I don't have a BSD host to check the round-trip end to end; the change is a
one-line platform-detection addition mirroring the existing branches, and the
BSD `futimens` / `st_mtim` APIs it relies on are long-standing
(FreeBSD ≥ 11, OpenBSD ≥ 5.0, NetBSD ≥ 6.0).

---

AI-assisted; analysed, changed and build-checked by me, and I take
responsibility for it.
